### PR TITLE
increased number of replicas for transactions index

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,36 @@
+name: Go Build and Test
+
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, ready_for_review]
+  push:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15.5
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+          if [ -f Gopkg.toml ]; then
+              curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+              dep ensure
+          fi
+
+      - name: Build
+        run: cd cmd/proxy/ && go build -v .
+
+      - name: Run tests
+        run: go test ./...

--- a/templates/noKibana/transactions.go
+++ b/templates/noKibana/transactions.go
@@ -7,7 +7,7 @@ var Transactions = Object{
 	},
 	"settings": Object{
 		"number_of_shards":   5,
-		"number_of_replicas": 0,
+		"number_of_replicas": 1,
 		"index": Object{
 			"sort.field": Array{
 				"timestamp", "nonce",

--- a/templates/withKibana/transactions.go
+++ b/templates/withKibana/transactions.go
@@ -7,7 +7,7 @@ var Transactions = Object{
 	},
 	"settings": Object{
 		"number_of_shards":                                 5,
-		"number_of_replicas":                               0,
+		"number_of_replicas":                               1,
 		"opendistro.index_state_management.policy_id":      "transactions_policy",
 		"opendistro.index_state_management.rollover_alias": "transactions",
 		"index": Object{


### PR DESCRIPTION
The number of replicas for the `transactions` index should be increased to `1` as to allow a better performance for `search` operations and also provide aid for fail-over situations