### PR TITLE
Improves and fixes

### DIFF
--- a/converters/tokenMetaData.go
+++ b/converters/tokenMetaData.go
@@ -22,19 +22,25 @@ func PrepareTokenMetaData(pubKeyConverter core.PubkeyConverter, esdtInfo *esdt.E
 		creatorStr = pubKeyConverter.Encode(esdtInfo.TokenMetaData.Creator)
 	}
 
-	uris := esdtInfo.TokenMetaData.URIs
-	if len(uris) == 0 {
-		uris = nil
+	return &data.TokenMetaData{
+		Name:         string(esdtInfo.TokenMetaData.Name),
+		Creator:      creatorStr,
+		Royalties:    esdtInfo.TokenMetaData.Royalties,
+		Hash:         esdtInfo.TokenMetaData.Hash,
+		URIs:         esdtInfo.TokenMetaData.URIs,
+		Attributes:   esdtInfo.TokenMetaData.Attributes,
+		Tags:         ExtractTagsFromAttributes(esdtInfo.TokenMetaData.Attributes),
+		MetaData:     ExtractMetaDataFromAttributes(esdtInfo.TokenMetaData.Attributes),
+		NonEmptyURIs: nonEmptyURIs(esdtInfo.TokenMetaData.URIs),
+	}
+}
+
+func nonEmptyURIs(uris [][]byte) bool {
+	for _, uri := range uris {
+		if len(uri) > 0 {
+			return true
+		}
 	}
 
-	return &data.TokenMetaData{
-		Name:       string(esdtInfo.TokenMetaData.Name),
-		Creator:    creatorStr,
-		Royalties:  esdtInfo.TokenMetaData.Royalties,
-		Hash:       esdtInfo.TokenMetaData.Hash,
-		URIs:       uris,
-		Attributes: esdtInfo.TokenMetaData.Attributes,
-		Tags:       ExtractTagsFromAttributes(esdtInfo.TokenMetaData.Attributes),
-		MetaData:   ExtractMetaDataFromAttributes(esdtInfo.TokenMetaData.Attributes),
-	}
+	return false
 }

--- a/converters/tokenMetaData_test.go
+++ b/converters/tokenMetaData_test.go
@@ -16,14 +16,15 @@ func TestPrepareTokenMetaData(t *testing.T) {
 	require.Nil(t, PrepareTokenMetaData(&mock.PubkeyConverterMock{}, nil))
 
 	expectedTokenMetaData := &data.TokenMetaData{
-		Name:       "token",
-		Creator:    "63726561746f72",
-		Royalties:  0,
-		Hash:       []byte("hash"),
-		URIs:       nil,
-		Attributes: []byte("tags:test,free,fun;description:This is a test description for an awesome nft;metadata:metadata-test"),
-		Tags:       []string{"test", "free", "fun"},
-		MetaData:   "metadata-test",
+		Name:         "token",
+		Creator:      "63726561746f72",
+		Royalties:    0,
+		Hash:         []byte("hash"),
+		URIs:         [][]byte{[]byte("uri")},
+		Attributes:   []byte("tags:test,free,fun;description:This is a test description for an awesome nft;metadata:metadata-test"),
+		Tags:         []string{"test", "free", "fun"},
+		MetaData:     "metadata-test",
+		NonEmptyURIs: true,
 	}
 
 	result := PrepareTokenMetaData(&mock.PubkeyConverterMock{}, &esdt.ESDigitalToken{
@@ -33,7 +34,7 @@ func TestPrepareTokenMetaData(t *testing.T) {
 			Creator:    []byte("creator"),
 			Royalties:  0,
 			Hash:       []byte("hash"),
-			URIs:       nil,
+			URIs:       [][]byte{[]byte("uri")},
 			Attributes: []byte("tags:test,free,fun;description:This is a test description for an awesome nft;metadata:metadata-test"),
 		},
 	})

--- a/data/account.go
+++ b/data/account.go
@@ -25,14 +25,15 @@ type AccountInfo struct {
 
 // TokenMetaData holds data about a token metadata
 type TokenMetaData struct {
-	Name       string   `json:"name,omitempty"`
-	Creator    string   `json:"creator,omitempty"`
-	Royalties  uint32   `json:"royalties,omitempty"`
-	Hash       []byte   `json:"hash,omitempty"`
-	URIs       [][]byte `json:"uris,omitempty"`
-	Tags       []string `json:"tags,omitempty"`
-	Attributes []byte   `json:"attributes,omitempty"`
-	MetaData   string   `json:"metadata,omitempty"`
+	Name         string   `json:"name,omitempty"`
+	Creator      string   `json:"creator,omitempty"`
+	Royalties    uint32   `json:"royalties,omitempty"`
+	Hash         []byte   `json:"hash,omitempty"`
+	URIs         [][]byte `json:"uris,omitempty"`
+	Tags         []string `json:"tags,omitempty"`
+	Attributes   []byte   `json:"attributes,omitempty"`
+	MetaData     string   `json:"metadata,omitempty"`
+	NonEmptyURIs bool     `json:"nonEmptyURIs"`
 }
 
 // AccountBalanceHistory represents an entry in the user accounts balances history

--- a/process/accounts/serialize.go
+++ b/process/accounts/serialize.go
@@ -2,8 +2,10 @@ package accounts
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math/big"
 
 	"github.com/ElrondNetwork/elastic-indexer-go/data"
 )
@@ -74,7 +76,9 @@ func prepareSerializedAccountInfo(
 ) ([]byte, []byte, error) {
 	id := account.Address
 	if isESDTAccount {
-		id += fmt.Sprintf("-%s-%d", account.TokenName, account.TokenNonce)
+		nonceBigBytes := big.NewInt(0).SetUint64(account.TokenNonce).Bytes()
+		hexEncodedNonce := hex.EncodeToString(nonceBigBytes)
+		id += fmt.Sprintf("-%s-%s", account.TokenName, hexEncodedNonce)
 	}
 
 	meta := []byte(fmt.Sprintf(`{ "index" : { "_id" : "%s" } }%s`, id, "\n"))

--- a/process/accounts/serialize_test.go
+++ b/process/accounts/serialize_test.go
@@ -78,7 +78,7 @@ func TestSerializeAccountsESDT(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(res))
 
-	expectedRes := `{ "index" : { "_id" : "addr1-token-0001-5" } }
+	expectedRes := `{ "index" : { "_id" : "addr1-token-0001-05" } }
 {"address":"addr1","nonce":1,"balance":"10000000000000","balanceNum":1,"token":"token-0001","tokenNonce":5,"properties":"000"}
 `
 	require.Equal(t, expectedRes, res[0].String())
@@ -93,7 +93,7 @@ func TestSerializeAccountsNFTWithMedaData(t *testing.T) {
 			Nonce:           1,
 			TokenName:       "token-0001",
 			Properties:      "000",
-			TokenNonce:      5,
+			TokenNonce:      22,
 			Balance:         "10000000000000",
 			BalanceNum:      1,
 			TokenIdentifier: "token-0001-5",
@@ -116,8 +116,8 @@ func TestSerializeAccountsNFTWithMedaData(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(res))
 
-	expectedRes := `{ "index" : { "_id" : "addr1-token-0001-5" } }
-{"address":"addr1","nonce":1,"balance":"10000000000000","balanceNum":1,"token":"token-0001","identifier":"token-0001-5","tokenNonce":5,"properties":"000","data":{"name":"nft","creator":"010101","royalties":1,"hash":"aGFzaA==","uris":["dXJp"],"tags":["test","free","fun"],"attributes":"dGFnczp0ZXN0LGZyZWUsZnVuO2Rlc2NyaXB0aW9uOlRoaXMgaXMgYSB0ZXN0IGRlc2NyaXB0aW9uIGZvciBhbiBhd2Vzb21lIG5mdA==","metadata":"metadata-test"}}
+	expectedRes := `{ "index" : { "_id" : "addr1-token-0001-16" } }
+{"address":"addr1","nonce":1,"balance":"10000000000000","balanceNum":1,"token":"token-0001","identifier":"token-0001-5","tokenNonce":22,"properties":"000","data":{"name":"nft","creator":"010101","royalties":1,"hash":"aGFzaA==","uris":["dXJp"],"tags":["test","free","fun"],"attributes":"dGFnczp0ZXN0LGZyZWUsZnVuO2Rlc2NyaXB0aW9uOlRoaXMgaXMgYSB0ZXN0IGRlc2NyaXB0aW9uIGZvciBhbiBhd2Vzb21lIG5mdA==","metadata":"metadata-test"}}
 `
 	require.Equal(t, expectedRes, res[0].String())
 }

--- a/process/accounts/serialize_test.go
+++ b/process/accounts/serialize_test.go
@@ -28,7 +28,7 @@ func TestSerializeNFTCreateInfo(t *testing.T) {
 	require.Equal(t, 1, len(res))
 
 	expectedRes := `{ "index" : { "_id" : "my-token-001-0f" } }
-{"identifier":"my-token-001-0f","token":"my-token-0001","type":"NonFungibleESDT","data":{"creator":"010102"}}
+{"identifier":"my-token-001-0f","token":"my-token-0001","type":"NonFungibleESDT","data":{"creator":"010102","nonEmptyURIs":false}}
 `
 	require.Equal(t, expectedRes, res[0].String())
 }
@@ -105,9 +105,10 @@ func TestSerializeAccountsNFTWithMedaData(t *testing.T) {
 				URIs: [][]byte{
 					[]byte("uri"),
 				},
-				Attributes: []byte("tags:test,free,fun;description:This is a test description for an awesome nft"),
-				Tags:       converters.ExtractTagsFromAttributes([]byte("tags:test,free,fun;description:This is a test description for an awesome nft")),
-				MetaData:   "metadata-test",
+				Attributes:   []byte("tags:test,free,fun;description:This is a test description for an awesome nft"),
+				Tags:         converters.ExtractTagsFromAttributes([]byte("tags:test,free,fun;description:This is a test description for an awesome nft")),
+				MetaData:     "metadata-test",
+				NonEmptyURIs: true,
 			},
 		},
 	}
@@ -117,7 +118,7 @@ func TestSerializeAccountsNFTWithMedaData(t *testing.T) {
 	require.Equal(t, 1, len(res))
 
 	expectedRes := `{ "index" : { "_id" : "addr1-token-0001-16" } }
-{"address":"addr1","nonce":1,"balance":"10000000000000","balanceNum":1,"token":"token-0001","identifier":"token-0001-5","tokenNonce":22,"properties":"000","data":{"name":"nft","creator":"010101","royalties":1,"hash":"aGFzaA==","uris":["dXJp"],"tags":["test","free","fun"],"attributes":"dGFnczp0ZXN0LGZyZWUsZnVuO2Rlc2NyaXB0aW9uOlRoaXMgaXMgYSB0ZXN0IGRlc2NyaXB0aW9uIGZvciBhbiBhd2Vzb21lIG5mdA==","metadata":"metadata-test"}}
+{"address":"addr1","nonce":1,"balance":"10000000000000","balanceNum":1,"token":"token-0001","identifier":"token-0001-5","tokenNonce":22,"properties":"000","data":{"name":"nft","creator":"010101","royalties":1,"hash":"aGFzaA==","uris":["dXJp"],"tags":["test","free","fun"],"attributes":"dGFnczp0ZXN0LGZyZWUsZnVuO2Rlc2NyaXB0aW9uOlRoaXMgaXMgYSB0ZXN0IGRlc2NyaXB0aW9uIGZvciBhbiBhd2Vzb21lIG5mdA==","metadata":"metadata-test","nonEmptyURIs":true}}
 `
 	require.Equal(t, expectedRes, res[0].String())
 }


### PR DESCRIPTION
Bugfix: change how ID on an `accoutsesdt` document is created

Added an extra field `nonEmptyURIs` in the document that is indexed in `accountsesdt` index