### PR TITLE
ES Client logging middleware

### DIFF
--- a/client/elasticClient_test.go
+++ b/client/elasticClient_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	indexer "github.com/ElrondNetwork/elastic-indexer-go"
+	"github.com/ElrondNetwork/elastic-indexer-go/client/logging"
 	"github.com/ElrondNetwork/elastic-indexer-go/data"
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/stretchr/testify/require"
@@ -57,6 +58,7 @@ func TestElasticClient_DoMultiGet(t *testing.T) {
 
 	esClient, _ := NewElasticClient(elasticsearch.Config{
 		Addresses: []string{ts.URL},
+		Logger:    &logging.CustomLogger{},
 	})
 
 	ids := []string{"id"}

--- a/client/logging/customLogger.go
+++ b/client/logging/customLogger.go
@@ -11,8 +11,10 @@ import (
 
 var log = logger.GetOrCreate("indexer/client/requests")
 
+// CustomLogger defines a custom logger for the elastic client
 type CustomLogger struct{}
 
+// LogRoundTrip logs useful information about the client request and response
 func (cl *CustomLogger) LogRoundTrip(
 	req *http.Request,
 	res *http.Response,
@@ -21,15 +23,15 @@ func (cl *CustomLogger) LogRoundTrip(
 	dur time.Duration,
 ) error {
 	var (
-		nReq int64
-		nRes int64
+		reqSize int64
+		resSize int64
 	)
 
 	if req != nil && req.Body != nil && req.Body != http.NoBody {
-		nReq, _ = io.Copy(ioutil.Discard, req.Body)
+		reqSize, _ = io.Copy(ioutil.Discard, req.Body)
 	}
 	if res != nil && res.Body != nil && res.Body != http.NoBody {
-		nRes, _ = io.Copy(ioutil.Discard, res.Body)
+		resSize, _ = io.Copy(ioutil.Discard, res.Body)
 	}
 
 	if err != nil {
@@ -37,7 +39,7 @@ func (cl *CustomLogger) LogRoundTrip(
 	}
 
 	if req != nil && res != nil {
-		logInformation(req, res, err, dur, nReq, nRes)
+		logInformation(req, res, err, dur, reqSize, resSize)
 	}
 
 	return nil
@@ -48,15 +50,15 @@ func logInformation(
 	res *http.Response,
 	err error,
 	dur time.Duration,
-	nReq int64,
-	nRes int64,
+	reqSize int64,
+	resSize int64,
 ) {
 	logData := []interface{}{
 		"method", req.Method,
 		"status code", res.StatusCode,
 		"duration", dur,
-		"request bytes", nReq,
-		"response bytes", nRes,
+		"request bytes", reqSize,
+		"response bytes", resSize,
 		"URL", req.URL.String(),
 	}
 	if err != nil {

--- a/client/logging/customLogger.go
+++ b/client/logging/customLogger.go
@@ -1,0 +1,78 @@
+package logging
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	logger "github.com/ElrondNetwork/elrond-go-logger"
+)
+
+var log = logger.GetOrCreate("indexer/client/requests")
+
+type CustomLogger struct{}
+
+func (cl *CustomLogger) LogRoundTrip(
+	req *http.Request,
+	res *http.Response,
+	err error,
+	_ time.Time,
+	dur time.Duration,
+) error {
+	var (
+		nReq int64
+		nRes int64
+	)
+
+	if req != nil && req.Body != nil && req.Body != http.NoBody {
+		nReq, _ = io.Copy(ioutil.Discard, req.Body)
+	}
+	if res != nil && res.Body != nil && res.Body != http.NoBody {
+		nRes, _ = io.Copy(ioutil.Discard, res.Body)
+	}
+
+	if err != nil {
+		log.Warn("elastic client", "error", err.Error())
+	}
+
+	if req != nil && res != nil {
+		logInformation(req, res, err, dur, nReq, nRes)
+	}
+
+	return nil
+}
+
+func logInformation(
+	req *http.Request,
+	res *http.Response,
+	err error,
+	dur time.Duration,
+	nReq int64,
+	nRes int64,
+) {
+	logData := []interface{}{
+		"method", req.Method,
+		"status code", res.StatusCode,
+		"duration", dur,
+		"request bytes", nReq,
+		"response bytes", nRes,
+		"URL", req.URL.String(),
+	}
+	if err != nil {
+		log.Warn("elastic client", logData...)
+		return
+	}
+
+	log.Debug("elastic client", logData...)
+}
+
+// RequestBodyEnabled makes the client pass request body to logger
+func (cl *CustomLogger) RequestBodyEnabled() bool {
+	return true
+}
+
+// ResponseBodyEnabled makes the client pass response body to logger
+func (cl *CustomLogger) ResponseBodyEnabled() bool {
+	return true
+}

--- a/converters/tags.go
+++ b/converters/tags.go
@@ -41,8 +41,27 @@ func extractFromAttributes(attributes []byte, key string) []string {
 			continue
 		}
 
-		return strings.Split(sKeyValuesPair[1], valuesSeparator)
+		tagsSplit := strings.Split(sKeyValuesPair[1], valuesSeparator)
+
+		return extractNonEmpty(tagsSplit)
 	}
 
 	return nil
+}
+
+func extractNonEmpty(tags []string) []string {
+	nonEmptyTags := make([]string, 0)
+	for _, tag := range tags {
+		if tag == "" {
+			continue
+		}
+
+		nonEmptyTags = append(nonEmptyTags, tag)
+	}
+
+	if len(nonEmptyTags) == 0 {
+		return nil
+	}
+
+	return nonEmptyTags
 }

--- a/converters/tags_test.go
+++ b/converters/tags_test.go
@@ -40,4 +40,16 @@ func TestPrepareTagsShouldWork(t *testing.T) {
 	attributes = []byte("shard:1,3")
 	prepared = ExtractTagsFromAttributes(attributes)
 	require.Nil(t, prepared)
+
+	attributes = []byte("tags:;metadata:")
+	prepared = ExtractTagsFromAttributes(attributes)
+	require.Nil(t, prepared)
+
+	attributes = []byte("tags:,,,,,,;metadata:")
+	prepared = ExtractTagsFromAttributes(attributes)
+	require.Nil(t, prepared)
+
+	attributes = []byte("tags")
+	prepared = ExtractTagsFromAttributes(attributes)
+	require.Nil(t, prepared)
 }

--- a/factory/indexerFactory.go
+++ b/factory/indexerFactory.go
@@ -5,6 +5,7 @@ import (
 
 	indexer "github.com/ElrondNetwork/elastic-indexer-go"
 	"github.com/ElrondNetwork/elastic-indexer-go/client"
+	"github.com/ElrondNetwork/elastic-indexer-go/client/logging"
 	"github.com/ElrondNetwork/elastic-indexer-go/process/factory"
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/check"
@@ -81,6 +82,7 @@ func createElasticProcessor(args *ArgsIndexerFactory) (indexer.ElasticProcessor,
 		Addresses: []string{args.Url},
 		Username:  args.UserName,
 		Password:  args.Password,
+		Logger:    &logging.CustomLogger{},
 	})
 	if err != nil {
 		return nil, err

--- a/process/elasticProcessor.go
+++ b/process/elasticProcessor.go
@@ -299,7 +299,6 @@ func (ei *elasticProcessor) SaveHeader(
 		Index:      elasticIndexer.BlockIndex,
 		DocumentID: elasticBlock.Hash,
 		Body:       bytes.NewReader(buff.Bytes()),
-		Refresh:    "true",
 	}
 
 	err = ei.elasticClient.DoRequest(req)
@@ -325,7 +324,6 @@ func (ei *elasticProcessor) indexEpochInfoData(header nodeData.HeaderHandler) er
 		Index:      elasticIndexer.EpochInfoIndex,
 		DocumentID: fmt.Sprintf("%d", header.GetEpoch()),
 		Body:       bytes.NewReader(buff.Bytes()),
-		Refresh:    "true",
 	}
 
 	return ei.elasticClient.DoRequest(req)
@@ -547,7 +545,6 @@ func (ei *elasticProcessor) SaveShardValidatorsPubKeys(shardID, epoch uint32, sh
 		Index:      elasticIndexer.ValidatorsIndex,
 		DocumentID: fmt.Sprintf("%d_%d", shardID, epoch),
 		Body:       bytes.NewReader(buff.Bytes()),
-		Refresh:    "true",
 	}
 
 	return ei.elasticClient.DoRequest(req)

--- a/process/tags/serialize.go
+++ b/process/tags/serialize.go
@@ -11,6 +11,10 @@ import (
 func (tc *tagsCount) Serialize() ([]*bytes.Buffer, error) {
 	buffSlice := data.NewBufferSlice()
 	for tag, count := range tc.tags {
+		if tag == "" {
+			continue
+		}
+
 		meta := []byte(fmt.Sprintf(`{ "update" : { "_id" : "%s", "_type" : "_doc" } }%s`, tag, "\n"))
 		serializedDataStr := fmt.Sprintf(`{"script": {"source": "ctx._source.count += params.count","lang": "painless","params": {"count": %d}},"upsert": {"count": %d}}`, count, count)
 

--- a/process/tags/tagsCount.go
+++ b/process/tags/tagsCount.go
@@ -46,6 +46,10 @@ func (tc *tagsCount) ParseTags(tags []string) {
 
 	newTags := removeDuplicatedTags(tags)
 	for _, tag := range newTags {
+		if tag == "" {
+			continue
+		}
+
 		tc.tags[tag]++
 	}
 }


### PR DESCRIPTION
Added in the `elasticsearch` client a custom logger that will print all the HTTP requests and responses.