### PR TITLE
Remove validators pubkey save logic

### DIFF
--- a/dataIndexerArgs.go
+++ b/dataIndexerArgs.go
@@ -13,13 +13,11 @@ import (
 
 // ArgDataIndexer is struct that is used to store all components that are needed to create a indexer
 type ArgDataIndexer struct {
-	ShardCoordinator   sharding.Coordinator
-	Marshalizer        marshal.Marshalizer
-	EpochStartNotifier sharding.EpochStartEventNotifier
-	NodesCoordinator   sharding.NodesCoordinator
-	UseKibana          bool
-	DataDispatcher     DispatcherHandler
-	ElasticProcessor   ElasticProcessor
+	ShardCoordinator sharding.Coordinator
+	Marshalizer      marshal.Marshalizer
+	UseKibana        bool
+	DataDispatcher   DispatcherHandler
+	ElasticProcessor ElasticProcessor
 }
 
 // ArgElasticProcessor is struct that is used to store all components that are needed to an elastic indexer

--- a/dataIndexer_test.go
+++ b/dataIndexer_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"math/big"
-	"sync"
 	"testing"
 	"time"
 
@@ -24,7 +23,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go/process"
 	"github.com/ElrondNetwork/elrond-go/testscommon"
 	"github.com/elastic/go-elasticsearch/v7"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,22 +43,11 @@ func newTestMetaBlock() *dataBlock.MetaBlock {
 
 func NewDataIndexerArguments() ArgDataIndexer {
 	return ArgDataIndexer{
-		Marshalizer:        &mock.MarshalizerMock{},
-		NodesCoordinator:   &mock.NodesCoordinatorMock{},
-		EpochStartNotifier: &mock.EpochStartNotifierStub{},
-		DataDispatcher:     &mock.DispatcherMock{},
-		ElasticProcessor:   &mock.ElasticProcessorStub{},
-		ShardCoordinator:   &mock.ShardCoordinatorMock{},
+		Marshalizer:      &mock.MarshalizerMock{},
+		DataDispatcher:   &mock.DispatcherMock{},
+		ElasticProcessor: &mock.ElasticProcessorStub{},
+		ShardCoordinator: &mock.ShardCoordinatorMock{},
 	}
-}
-
-func TestDataIndexer_NewIndexerWithNilNodesCoordinatorShouldErr(t *testing.T) {
-	arguments := NewDataIndexerArguments()
-	arguments.NodesCoordinator = nil
-	ei, err := NewDataIndexer(arguments)
-
-	require.Nil(t, ei)
-	require.Equal(t, core.ErrNilNodesCoordinator, err)
 }
 
 func TestDataIndexer_NewIndexerWithNilDataDispatcherShouldErr(t *testing.T) {
@@ -88,15 +75,6 @@ func TestDataIndexer_NewIndexerWithNilMarshalizerShouldErr(t *testing.T) {
 
 	require.Nil(t, ei)
 	require.Equal(t, core.ErrNilMarshalizer, err)
-}
-
-func TestDataIndexer_NewIndexerWithNilEpochStartNotifierShouldErr(t *testing.T) {
-	arguments := NewDataIndexerArguments()
-	arguments.EpochStartNotifier = nil
-	ei, err := NewDataIndexer(arguments)
-
-	require.Nil(t, ei)
-	require.Equal(t, core.ErrNilEpochStartNotifier, err)
 }
 
 func TestDataIndexer_NewIndexerWithCorrectParamsShouldWork(t *testing.T) {
@@ -248,99 +226,6 @@ func TestDataIndexer_SetTxLogsProcessor(t *testing.T) {
 	require.True(t, called)
 }
 
-func TestDataIndexer_EpochChange(t *testing.T) {
-	getEligibleValidatorsCalled := false
-
-	_ = logger.SetLogLevel("core/indexer:TRACE")
-	arguments := NewDataIndexerArguments()
-	arguments.Marshalizer = &mock.MarshalizerMock{Fail: true}
-	arguments.ShardCoordinator = &mock.ShardCoordinatorMock{
-		SelfID: core.MetachainShardId,
-	}
-	epochChangeNotifier := &mock.EpochStartNotifierStub{}
-	arguments.EpochStartNotifier = epochChangeNotifier
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	testEpoch := uint32(1)
-	arguments.NodesCoordinator = &mock.NodesCoordinatorMock{
-		GetAllEligibleValidatorsPublicKeysCalled: func(epoch uint32) (m map[uint32][][]byte, err error) {
-			defer wg.Done()
-			if testEpoch == epoch {
-				getEligibleValidatorsCalled = true
-			}
-
-			return nil, nil
-		},
-	}
-
-	ei, _ := NewDataIndexer(arguments)
-	assert.NotNil(t, ei)
-
-	epochChangeNotifier.NotifyAll(&dataBlock.Header{Nonce: 1, Epoch: testEpoch})
-	wg.Wait()
-
-	assert.True(t, getEligibleValidatorsCalled)
-}
-
-func TestDataIndexer_EpochChangeValidators(t *testing.T) {
-	_ = logger.SetLogLevel("core/indexer:TRACE")
-	arguments := NewDataIndexerArguments()
-	arguments.Marshalizer = &mock.MarshalizerMock{Fail: true}
-	arguments.ShardCoordinator = &mock.ShardCoordinatorMock{
-		SelfID: core.MetachainShardId,
-	}
-	epochChangeNotifier := &mock.EpochStartNotifierStub{}
-	arguments.EpochStartNotifier = epochChangeNotifier
-
-	var wg sync.WaitGroup
-
-	val1PubKey := []byte("val1")
-	val2PubKey := []byte("val2")
-	val1MetaPubKey := []byte("val3")
-	val2MetaPubKey := []byte("val4")
-
-	validatorsEpoch1 := map[uint32][][]byte{
-		0:                     {val1PubKey, val2PubKey},
-		core.MetachainShardId: {val1MetaPubKey, val2MetaPubKey},
-	}
-	validatorsEpoch2 := map[uint32][][]byte{
-		0:                     {val2PubKey, val1PubKey},
-		core.MetachainShardId: {val2MetaPubKey, val1MetaPubKey},
-	}
-	var firstEpochCalled, secondEpochCalled bool
-	arguments.NodesCoordinator = &mock.NodesCoordinatorMock{
-		GetAllEligibleValidatorsPublicKeysCalled: func(epoch uint32) (m map[uint32][][]byte, err error) {
-			defer wg.Done()
-
-			switch epoch {
-			case 1:
-				firstEpochCalled = true
-				return validatorsEpoch1, nil
-			case 2:
-				secondEpochCalled = true
-				return validatorsEpoch2, nil
-			default:
-				return nil, nil
-			}
-		},
-	}
-
-	ei, _ := NewDataIndexer(arguments)
-	assert.NotNil(t, ei)
-
-	wg.Add(1)
-	epochChangeNotifier.NotifyAll(&dataBlock.Header{Nonce: 1, Epoch: 1})
-	wg.Wait()
-	assert.True(t, firstEpochCalled)
-
-	wg.Add(1)
-	epochChangeNotifier.NotifyAll(&dataBlock.Header{Nonce: 10, Epoch: 2})
-	wg.Wait()
-	assert.True(t, secondEpochCalled)
-}
-
 func TestDataIndexer(t *testing.T) {
 	t.Skip("this is not a short test")
 
@@ -369,10 +254,9 @@ func testCreateIndexer(t *testing.T) {
 	})
 
 	di, err := NewDataIndexer(ArgDataIndexer{
-		Marshalizer:        &marshal.JsonMarshalizer{},
-		EpochStartNotifier: &mock.EpochStartNotifierStub{},
-		DataDispatcher:     dispatcher,
-		ElasticProcessor:   elasticIndexer,
+		Marshalizer:      &marshal.JsonMarshalizer{},
+		DataDispatcher:   dispatcher,
+		ElasticProcessor: elasticIndexer,
 	})
 	if err != nil {
 		fmt.Println(err)

--- a/factory/indexerFactory.go
+++ b/factory/indexerFactory.go
@@ -25,8 +25,6 @@ type ArgsIndexerFactory struct {
 	Password                 string
 	Marshalizer              marshal.Marshalizer
 	Hasher                   hashing.Hasher
-	EpochStartNotifier       sharding.EpochStartEventNotifier
-	NodesCoordinator         sharding.NodesCoordinator
 	AddressPubkeyConverter   core.PubkeyConverter
 	ValidatorPubkeyConverter core.PubkeyConverter
 	UseKibana                bool
@@ -61,13 +59,11 @@ func NewIndexer(args *ArgsIndexerFactory) (process.Indexer, error) {
 	dispatcher.StartIndexData()
 
 	arguments := indexer.ArgDataIndexer{
-		Marshalizer:        args.Marshalizer,
-		UseKibana:          args.UseKibana,
-		NodesCoordinator:   args.NodesCoordinator,
-		EpochStartNotifier: args.EpochStartNotifier,
-		ShardCoordinator:   args.ShardCoordinator,
-		ElasticProcessor:   elasticProcessor,
-		DataDispatcher:     dispatcher,
+		Marshalizer:      args.Marshalizer,
+		UseKibana:        args.UseKibana,
+		ShardCoordinator: args.ShardCoordinator,
+		ElasticProcessor: elasticProcessor,
+		DataDispatcher:   dispatcher,
 	}
 
 	return indexer.NewDataIndexer(arguments)
@@ -138,12 +134,6 @@ func checkDataIndexerParams(arguments *ArgsIndexerFactory) error {
 	}
 	if check.IfNil(arguments.Hasher) {
 		return core.ErrNilHasher
-	}
-	if check.IfNil(arguments.NodesCoordinator) {
-		return core.ErrNilNodesCoordinator
-	}
-	if check.IfNil(arguments.EpochStartNotifier) {
-		return core.ErrNilEpochStartNotifier
 	}
 	if check.IfNil(arguments.TransactionFeeCalculator) {
 		return core.ErrNilTransactionFeeCalculator

--- a/factory/indexerFactory_test.go
+++ b/factory/indexerFactory_test.go
@@ -25,8 +25,6 @@ func createMockIndexerFactoryArgs() *ArgsIndexerFactory {
 		Password:                 "",
 		Marshalizer:              &mock.MarshalizerMock{},
 		Hasher:                   &mock.HasherMock{},
-		EpochStartNotifier:       &mock.EpochStartNotifierStub{},
-		NodesCoordinator:         &mock.NodesCoordinatorMock{},
 		AddressPubkeyConverter:   &mock.PubkeyConverterMock{},
 		ValidatorPubkeyConverter: &mock.PubkeyConverterMock{},
 		EnabledIndexes:           []string{"blocks", "transactions", "miniblocks", "tps", "validators", "round", "accounts", "rating"},
@@ -87,24 +85,6 @@ func TestNewIndexerFactory(t *testing.T) {
 				return args
 			},
 			exError: core.ErrNilHasher,
-		},
-		{
-			name: "NilNodesCoordinator",
-			argsFunc: func() *ArgsIndexerFactory {
-				args := createMockIndexerFactoryArgs()
-				args.NodesCoordinator = nil
-				return args
-			},
-			exError: core.ErrNilNodesCoordinator,
-		},
-		{
-			name: "NilEpochStartNotifier",
-			argsFunc: func() *ArgsIndexerFactory {
-				args := createMockIndexerFactoryArgs()
-				args.EpochStartNotifier = nil
-				return args
-			},
-			exError: core.ErrNilEpochStartNotifier,
 		},
 		{
 			name: "NilAccountsDB",


### PR DESCRIPTION
- removed the logic that saves the validators public keys from the elastic indexer.
- this logic with notifications should stay on the node side