### PR TITLE
Token index fix

### DIFF
--- a/data/logs.go
+++ b/data/logs.go
@@ -1,10 +1,13 @@
 package data
 
+import "time"
+
 // Logs holds all the fields needed for a logs structure
 type Logs struct {
-	ID      string   `json:"-"`
-	Address string   `json:"address"`
-	Events  []*Event `json:"events"`
+	ID        string        `json:"-"`
+	Address   string        `json:"address"`
+	Events    []*Event      `json:"events"`
+	Timestamp time.Duration `json:"timestamp,omitempty"`
 }
 
 // Event holds all the fields needed for an event structure

--- a/data/tokens.go
+++ b/data/tokens.go
@@ -27,6 +27,7 @@ type TokenInfo struct {
 	Token      string         `json:"token,omitempty"`
 	Issuer     string         `json:"issuer,omitempty"`
 	Type       string         `json:"type,omitempty"`
+	Nonce      uint64         `json:"nonce,omitempty"`
 	Timestamp  time.Duration  `json:"timestamp,omitempty"`
 	Data       *TokenMetaData `json:"data,omitempty"`
 }
@@ -53,7 +54,12 @@ func NewTokensInfo() *tokensInfo {
 
 // Add will add tokenInfo
 func (ti *tokensInfo) Add(tokenInfo *TokenInfo) {
-	ti.tokensInfo[tokenInfo.Token] = tokenInfo
+	mapKey := tokenInfo.Token
+	if tokenInfo.Identifier != "" {
+		mapKey = tokenInfo.Identifier
+	}
+
+	ti.tokensInfo[mapKey] = tokenInfo
 }
 
 // GetAll will return all tokens information

--- a/data/tokens_test.go
+++ b/data/tokens_test.go
@@ -13,10 +13,11 @@ func TestTokensInfo_AddGet(t *testing.T) {
 	tokensData := NewTokensInfo()
 
 	tokensData.Add(&TokenInfo{
-		Token: "my-token-1",
+		Token:      "my-token-1",
+		Identifier: "my-token-1-01",
 	})
 	tokensData.Add(&TokenInfo{
-		Token: "my-token-2",
+		Token: "my-token-1",
 	})
 
 	res := tokensData.GetAllTokens()
@@ -24,6 +25,9 @@ func TestTokensInfo_AddGet(t *testing.T) {
 
 	res2 := tokensData.GetAll()
 	require.Len(t, res2, 2)
+
+	_, found := tokensData.tokensInfo["my-token-1-01"]
+	require.True(t, found)
 }
 
 func TestTokensInfo_AddTypeFromResponse(t *testing.T) {

--- a/process/interface.go
+++ b/process/interface.go
@@ -83,7 +83,7 @@ type DBValidatorsHandler interface {
 
 // DBLogsAndEventsHandler defines the actions that a logs and events handler should do
 type DBLogsAndEventsHandler interface {
-	PrepareLogsForDB(logsAndEvents map[string]coreData.LogHandler) []*data.Logs
+	PrepareLogsForDB(logsAndEvents map[string]coreData.LogHandler, timestamp uint64) []*data.Logs
 	ExtractDataFromLogs(
 		logsAndEvents map[string]coreData.LogHandler,
 		preparedResults *data.PreparedResults,

--- a/process/logsevents/logsAndEventsProcessor.go
+++ b/process/logsevents/logsAndEventsProcessor.go
@@ -2,6 +2,7 @@ package logsevents
 
 import (
 	"encoding/hex"
+	"time"
 
 	elasticIndexer "github.com/ElrondNetwork/elastic-indexer-go"
 	"github.com/ElrondNetwork/elastic-indexer-go/data"
@@ -120,7 +121,10 @@ func (lep *logsAndEventsProcessor) processEvent(logHash string, events coreData.
 }
 
 // PrepareLogsForDB will prepare logs for database
-func (lep *logsAndEventsProcessor) PrepareLogsForDB(logsAndEvents map[string]coreData.LogHandler) []*data.Logs {
+func (lep *logsAndEventsProcessor) PrepareLogsForDB(
+	logsAndEvents map[string]coreData.LogHandler,
+	timestamp uint64,
+) []*data.Logs {
 	logs := make([]*data.Logs, 0, len(logsAndEvents))
 
 	for txHash, log := range logsAndEvents {
@@ -128,18 +132,23 @@ func (lep *logsAndEventsProcessor) PrepareLogsForDB(logsAndEvents map[string]cor
 			continue
 		}
 
-		logs = append(logs, lep.prepareLogsForDB(txHash, log))
+		logs = append(logs, lep.prepareLogsForDB(txHash, log, timestamp))
 	}
 
 	return logs
 }
 
-func (lep *logsAndEventsProcessor) prepareLogsForDB(id string, logHandler coreData.LogHandler) *data.Logs {
+func (lep *logsAndEventsProcessor) prepareLogsForDB(
+	id string,
+	logHandler coreData.LogHandler,
+	timestamp uint64,
+) *data.Logs {
 	events := logHandler.GetLogEvents()
 	logsDB := &data.Logs{
-		ID:      hex.EncodeToString([]byte(id)),
-		Address: lep.pubKeyConverter.Encode(logHandler.GetAddress()),
-		Events:  make([]*data.Event, 0, len(events)),
+		ID:        hex.EncodeToString([]byte(id)),
+		Address:   lep.pubKeyConverter.Encode(logHandler.GetAddress()),
+		Timestamp: time.Duration(timestamp),
+		Events:    make([]*data.Event, 0, len(events)),
 	}
 
 	for _, event := range events {

--- a/process/logsevents/logsAndEventsProcessor_test.go
+++ b/process/logsevents/logsAndEventsProcessor_test.go
@@ -3,6 +3,7 @@ package logsevents
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	elasticIndexer "github.com/ElrondNetwork/elastic-indexer-go"
 	"github.com/ElrondNetwork/elastic-indexer-go/data"
@@ -117,10 +118,11 @@ func TestLogsAndEventsProcessor_PrepareLogsForDB(t *testing.T) {
 
 	proc, _ := NewLogsAndEventsProcessor(&mock.ShardCoordinatorMock{}, mock.NewPubkeyConverterMock(32), &mock.MarshalizerMock{})
 
-	logsDB := proc.PrepareLogsForDB(logsAndEvents)
+	logsDB := proc.PrepareLogsForDB(logsAndEvents, 1234)
 	require.Equal(t, &data.Logs{
-		ID:      "747848617368",
-		Address: "61646472657373",
+		ID:        "747848617368",
+		Address:   "61646472657373",
+		Timestamp: time.Duration(1234),
 		Events: []*data.Event{
 			{
 				Address:    "61646472",

--- a/process/logsevents/nftsProcessor.go
+++ b/process/logsevents/nftsProcessor.go
@@ -149,6 +149,7 @@ func (np *nftsProcessor) processNFTEventOnSender(
 		Identifier: converters.ComputeTokenIdentifier(token, nonceBig.Uint64()),
 		Timestamp:  time.Duration(timestamp),
 		Data:       tokenMetaData,
+		Nonce:      nonceBig.Uint64(),
 	})
 
 	if tokenMetaData != nil {

--- a/process/logsevents/nftsProcessor_test.go
+++ b/process/logsevents/nftsProcessor_test.go
@@ -60,6 +60,7 @@ func TestNftsProcessor_processLogAndEventsNFTs(t *testing.T) {
 		Token:      "my-token",
 		Timestamp:  1000,
 		Issuer:     "",
+		Nonce:      uint64(19),
 		Data: &data.TokenMetaData{
 			Creator: hex.EncodeToString([]byte("creator")),
 		},

--- a/process/logsevents/serialize_test.go
+++ b/process/logsevents/serialize_test.go
@@ -3,6 +3,7 @@ package logsevents
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ElrondNetwork/elastic-indexer-go/data"
 	"github.com/ElrondNetwork/elrond-go-core/core"
@@ -14,8 +15,9 @@ func TestLogsAndEventsProcessor_SerializeLogs(t *testing.T) {
 
 	logs := []*data.Logs{
 		{
-			ID:      "747848617368",
-			Address: "61646472657373",
+			ID:        "747848617368",
+			Address:   "61646472657373",
+			Timestamp: time.Duration(1234),
 			Events: []*data.Event{
 				{
 					Address:    "61646472",
@@ -31,7 +33,7 @@ func TestLogsAndEventsProcessor_SerializeLogs(t *testing.T) {
 	require.Nil(t, err)
 
 	expectedRes := `{ "index" : { "_id" : "747848617368" } }
-{"address":"61646472657373","events":[{"address":"61646472","identifier":"ESDTNFTTransfer","topics":["bXktdG9rZW4=","AQ==","cmVjZWl2ZXI="],"data":"ZGF0YQ=="}]}
+{"address":"61646472657373","events":[{"address":"61646472","identifier":"ESDTNFTTransfer","topics":["bXktdG9rZW4=","AQ==","cmVjZWl2ZXI="],"data":"ZGF0YQ=="}],"timestamp":1234}
 `
 	require.Equal(t, expectedRes, res[0].String())
 }

--- a/templates/noKibana/logs.go
+++ b/templates/noKibana/logs.go
@@ -28,6 +28,10 @@ var Logs = Object{
 					},
 				},
 			},
+			"timestamp": Object{
+				"type":   "date",
+				"format": "epoch_second",
+			},
 		},
 	},
 }

--- a/templates/withKibana/logs.go
+++ b/templates/withKibana/logs.go
@@ -29,5 +29,9 @@ var Logs = Object{
 				},
 			},
 		},
+		"timestamp": Object{
+			"type":   "date",
+			"format": "epoch_second",
+		},
 	},
 }


### PR DESCRIPTION
Fix the key in the map ---- in case of NFT Create key in tokens map will be token identifier instead of token.
This bug appears when we have multiple NFTCreate operations from the same collection but different nonces. 

Added timestamp in logs that are indexed.