### PR TITLE
add receiver account in case of ESDT and NFT operations

### DIFF
--- a/data/altered.go
+++ b/data/altered.go
@@ -2,6 +2,7 @@ package data
 
 // AlteredAccount is a structure that holds information about an altered account
 type AlteredAccount struct {
+	BalanceChange   bool
 	IsSender        bool
 	IsESDTOperation bool
 	IsNFTOperation  bool

--- a/data/altered_test.go
+++ b/data/altered_test.go
@@ -13,7 +13,9 @@ func TestAlteredAccounts_Add(t *testing.T) {
 	altAccounts := NewAlteredAccounts()
 
 	addr := "my-addr"
-	acct1 := &AlteredAccount{}
+	acct1 := &AlteredAccount{
+		BalanceChange: true,
+	}
 	altAccounts.Add(addr, acct1)
 
 	acct2 := &AlteredAccount{
@@ -25,6 +27,30 @@ func TestAlteredAccounts_Add(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, 1, len(res))
 	require.True(t, res[0].IsSender)
+	require.True(t, res[0].BalanceChange)
+}
+
+func TestAlteredAccounts_AddTokenAddFunds(t *testing.T) {
+	t.Parallel()
+
+	altAccounts := NewAlteredAccounts()
+
+	addr := "my-addr"
+	acct1 := &AlteredAccount{
+		BalanceChange: true,
+	}
+	altAccounts.Add(addr, acct1)
+
+	acct2 := &AlteredAccount{
+		IsESDTOperation: true,
+		TokenIdentifier: "my-token",
+	}
+	altAccounts.Add(addr, acct2)
+
+	res, ok := altAccounts.Get(addr)
+	require.True(t, ok)
+	require.Equal(t, 1, len(res))
+	require.True(t, res[0].BalanceChange)
 }
 
 func TestAlteredAccounts_AddESDT(t *testing.T) {
@@ -32,7 +58,9 @@ func TestAlteredAccounts_AddESDT(t *testing.T) {
 
 	altAccounts := NewAlteredAccounts()
 
-	acct1 := &AlteredAccount{}
+	acct1 := &AlteredAccount{
+		BalanceChange: true,
+	}
 	addr := "my-addr"
 	altAccounts.Add(addr, acct1)
 
@@ -83,6 +111,7 @@ func TestAlteredAccounts_AddESDT(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, 3, len(res))
 	require.Equal(t, &AlteredAccount{
+		BalanceChange:   true,
 		IsSender:        true,
 		IsESDTOperation: true,
 		TokenIdentifier: "my-token",

--- a/process/accounts/accountsProcessor.go
+++ b/process/accounts/accountsProcessor.go
@@ -96,7 +96,8 @@ func splitAlteredAccounts(userAccount coreData.UserAccountHandler, altered []*da
 			})
 		}
 
-		ignoreESDTReceiver := (info.IsESDTOperation || info.IsNFTOperation) && !info.IsSender
+		// if the balance of the ESDT receiver is 0 the receiver is a new account most probably, and we should index it
+		ignoreESDTReceiver := (info.IsESDTOperation || info.IsNFTOperation) && !info.IsSender && notZeroBalance(userAccount)
 		if ignoreESDTReceiver {
 			continue
 		}
@@ -108,6 +109,14 @@ func splitAlteredAccounts(userAccount coreData.UserAccountHandler, altered []*da
 	}
 
 	return regularAccountsToIndex, accountsToIndexESDT
+}
+
+func notZeroBalance(userAccount coreData.UserAccountHandler) bool {
+	if userAccount.GetBalance() == nil {
+		return false
+	}
+
+	return userAccount.GetBalance().Cmp(big.NewInt(0)) > 0
 }
 
 func (ap *accountsProcessor) getUserAccount(address string) (coreData.UserAccountHandler, error) {

--- a/process/accounts/accountsProcessor.go
+++ b/process/accounts/accountsProcessor.go
@@ -97,8 +97,8 @@ func splitAlteredAccounts(userAccount coreData.UserAccountHandler, altered []*da
 		}
 
 		// if the balance of the ESDT receiver is 0 the receiver is a new account most probably, and we should index it
-		ignoreESDTReceiver := (info.IsESDTOperation || info.IsNFTOperation) && !info.IsSender && notZeroBalance(userAccount)
-		if ignoreESDTReceiver {
+		ignoreReceiver := !info.BalanceChange && notZeroBalance(userAccount) && !info.IsSender
+		if ignoreReceiver {
 			continue
 		}
 

--- a/process/transactions/smartContractResultsProcessor.go
+++ b/process/transactions/smartContractResultsProcessor.go
@@ -176,7 +176,8 @@ func (proc *smartContractResultsProcessor) addScrsReceiverToAlteredAccounts(
 		}
 
 		alteredAccounts.Add(scr.Receiver, &indexerData.AlteredAccount{
-			IsSender: false,
+			IsSender:      false,
+			BalanceChange: true,
 		})
 	}
 }

--- a/process/transactions/transactionsGrouper.go
+++ b/process/transactions/transactionsGrouper.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
 	"github.com/ElrondNetwork/elrond-go-core/data/receipt"
 	"github.com/ElrondNetwork/elrond-go-core/data/rewardTx"
-	"github.com/ElrondNetwork/elrond-go-core/data/smartContractResult"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
@@ -221,19 +220,6 @@ func computeStatus(selfShardID uint32, receiverShardID uint32) string {
 	return transaction.TxStatusPending.String()
 }
 
-func groupSmartContractResults(txsPool map[string]coreData.TransactionHandler) map[string]*smartContractResult.SmartContractResult {
-	scResults := make(map[string]*smartContractResult.SmartContractResult)
-	for hash, tx := range txsPool {
-		scResult, ok := tx.(*smartContractResult.SmartContractResult)
-		if !ok {
-			continue
-		}
-		scResults[hash] = scResult
-	}
-
-	return scResults
-}
-
 func convertMapTxsToSlice(txs map[string]*data.Transaction) []*data.Transaction {
 	transactions := make([]*data.Transaction, len(txs))
 	i := 0
@@ -253,7 +239,8 @@ func (tg *txsGrouper) addToAlteredAddresses(
 ) {
 	if selfShardID == miniBlock.SenderShardID && !isRewardTx {
 		alteredAccounts.Add(tx.Sender, &data.AlteredAccount{
-			IsSender: true,
+			IsSender:      true,
+			BalanceChange: true,
 		})
 	}
 
@@ -264,7 +251,8 @@ func (tg *txsGrouper) addToAlteredAddresses(
 
 	if selfShardID == miniBlock.ReceiverShardID || miniBlock.ReceiverShardID == core.AllShardId {
 		alteredAccounts.Add(tx.Receiver, &data.AlteredAccount{
-			IsSender: false,
+			IsSender:      false,
+			BalanceChange: true,
 		})
 	}
 }

--- a/process/transactions/transactionsProcessor_test.go
+++ b/process/transactions/transactionsProcessor_test.go
@@ -54,12 +54,15 @@ func TestAddToAlteredAddresses(t *testing.T) {
 
 	alteredAccounts, ok := alteredAddress.Get(receiver)
 	require.True(t, ok)
-	require.Equal(t, &data.AlteredAccount{}, alteredAccounts[0])
+	require.Equal(t, &data.AlteredAccount{
+		BalanceChange: true,
+	}, alteredAccounts[0])
 
 	alteredAccounts, ok = alteredAddress.Get(sender)
 	require.True(t, ok)
 	require.Equal(t, &data.AlteredAccount{
-		IsSender: true,
+		BalanceChange: true,
+		IsSender:      true,
 	}, alteredAccounts[0])
 }
 


### PR DESCRIPTION
Added the receiver of the ESDT transaction in the `accounts` index. 
This action is needed because is possible to create a new account when we do an ESDT/ NFT transfer.