### PR TITLE
do not delete cross shard miniblocks and rewards txs on import db

### DIFF
--- a/process/elasticProcessor_test.go
+++ b/process/elasticProcessor_test.go
@@ -50,7 +50,7 @@ func createMockElasticProcessorArgs() *ArgElasticProcessor {
 
 	acp, _ := accounts.NewAccountsProcessor(&mock.MarshalizerMock{}, &mock.PubkeyConverterMock{}, &mock.AccountsStub{}, balanceConverter)
 	bp, _ := block.NewBlockProcessor(&mock.HasherMock{}, &mock.MarshalizerMock{})
-	mp, _ := miniblocks.NewMiniblocksProcessor(0, &mock.HasherMock{}, &mock.MarshalizerMock{})
+	mp, _ := miniblocks.NewMiniblocksProcessor(0, &mock.HasherMock{}, &mock.MarshalizerMock{}, false)
 	vp, _ := validators.NewValidatorsProcessor(mock.NewPubkeyConverterMock(32))
 	lp, _ := logsevents.NewLogsAndEventsProcessor(&mock.ShardCoordinatorMock{}, &mock.PubkeyConverterMock{}, &mock.MarshalizerMock{}, balanceConverter, &mock.HasherMock{})
 
@@ -303,7 +303,7 @@ func TestElasticProcessor_RemoveMiniblocks(t *testing.T) {
 		},
 	}
 
-	args.MiniblocksProc, _ = miniblocks.NewMiniblocksProcessor(0, &mock.HasherMock{}, &mock.MarshalizerMock{})
+	args.MiniblocksProc, _ = miniblocks.NewMiniblocksProcessor(0, &mock.HasherMock{}, &mock.MarshalizerMock{}, false)
 
 	elasticProc, err := NewElasticProcessor(args)
 	require.NoError(t, err)
@@ -464,7 +464,7 @@ func TestElasticProcessor_SaveMiniblocks(t *testing.T) {
 		},
 	}
 
-	arguments.MiniblocksProc, _ = miniblocks.NewMiniblocksProcessor(0, &mock.HasherMock{}, &mock.MarshalizerMock{})
+	arguments.MiniblocksProc, _ = miniblocks.NewMiniblocksProcessor(0, &mock.HasherMock{}, &mock.MarshalizerMock{}, false)
 	elasticProc, _ := NewElasticProcessor(arguments)
 
 	header := &dataBlock.Header{}

--- a/process/factory/elasticProcessorFactory.go
+++ b/process/factory/elasticProcessorFactory.go
@@ -69,7 +69,7 @@ func CreateElasticProcessor(arguments ArgElasticProcessorFactory) (indexer.Elast
 		return nil, err
 	}
 
-	miniblocksProc, err := miniblocks.NewMiniblocksProcessor(arguments.ShardCoordinator.SelfId(), arguments.Hasher, arguments.Marshalizer)
+	miniblocksProc, err := miniblocks.NewMiniblocksProcessor(arguments.ShardCoordinator.SelfId(), arguments.Hasher, arguments.Marshalizer, arguments.IsInImportDBMode)
 	if err != nil {
 		return nil, err
 	}

--- a/process/miniblocks/serialize_test.go
+++ b/process/miniblocks/serialize_test.go
@@ -11,7 +11,7 @@ import (
 func TestMiniblocksProcessor_SerializeBulkMiniBlocks(t *testing.T) {
 	t.Parallel()
 
-	mp, _ := NewMiniblocksProcessor(0, mock.HasherMock{}, &mock.MarshalizerMock{})
+	mp, _ := NewMiniblocksProcessor(0, mock.HasherMock{}, &mock.MarshalizerMock{}, false)
 
 	miniblocks := []*data.Miniblock{
 		{Hash: "h1", SenderShardID: 0, ReceiverShardID: 1},
@@ -31,7 +31,7 @@ func TestMiniblocksProcessor_SerializeBulkMiniBlocks(t *testing.T) {
 func TestMiniblocksProcessor_SerializeBulkMiniBlocksInDB(t *testing.T) {
 	t.Parallel()
 
-	mp, _ := NewMiniblocksProcessor(0, mock.HasherMock{}, &mock.MarshalizerMock{})
+	mp, _ := NewMiniblocksProcessor(0, mock.HasherMock{}, &mock.MarshalizerMock{}, false)
 
 	miniblocks := []*data.Miniblock{
 		{Hash: "h1", SenderShardID: 0, ReceiverShardID: 1},

--- a/process/transactions/transactionsProcessor.go
+++ b/process/transactions/transactionsProcessor.go
@@ -160,6 +160,12 @@ func (tdp *txsDatabaseProcessor) GetRewardsTxsHashesHexEncoded(header coreData.H
 			continue
 		}
 
+		shouldIgnore := tdp.txsGrouper.isInImportMode && selfShardID == miniblock.SenderShardID
+		if shouldIgnore {
+			// do not delete rewards transactions from source shard on import DB
+			continue
+		}
+
 		isDstMe := selfShardID == miniblock.ReceiverShardID
 		if isDstMe {
 			// reward miniblock is always cross-shard


### PR DESCRIPTION
Do not delete cross-shard miniblocks in case of rollbacks.