### PR TITLE
use the logs as slice instead of map

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ElrondNetwork/elastic-indexer-go
 go 1.15
 
 require (
-	github.com/ElrondNetwork/elrond-go-core v1.1.5
+	github.com/ElrondNetwork/elrond-go-core v1.1.6-0.20211221104129-9205b629932f
 	github.com/ElrondNetwork/elrond-go-logger v1.0.5
 	github.com/ElrondNetwork/elrond-vm-common v1.1.1-0.20210722121034-4894ec636075
 	github.com/elastic/go-elasticsearch/v7 v7.12.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ElrondNetwork/elastic-indexer-go
 go 1.15
 
 require (
-	github.com/ElrondNetwork/elrond-go-core v1.1.6-0.20211222084447-ad4e72f6a2ef
+	github.com/ElrondNetwork/elrond-go-core v1.1.6-0.20211222113209-7f3f1ad307cd
 	github.com/ElrondNetwork/elrond-go-logger v1.0.5
 	github.com/ElrondNetwork/elrond-vm-common v1.1.1-0.20210722121034-4894ec636075
 	github.com/elastic/go-elasticsearch/v7 v7.12.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ElrondNetwork/elastic-indexer-go
 go 1.15
 
 require (
-	github.com/ElrondNetwork/elrond-go-core v1.1.6-0.20211221104129-9205b629932f
+	github.com/ElrondNetwork/elrond-go-core v1.1.6-0.20211222084447-ad4e72f6a2ef
 	github.com/ElrondNetwork/elrond-go-logger v1.0.5
 	github.com/ElrondNetwork/elrond-vm-common v1.1.1-0.20210722121034-4894ec636075
 	github.com/elastic/go-elasticsearch/v7 v7.12.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ElrondNetwork/elastic-indexer-go
 go 1.15
 
 require (
-	github.com/ElrondNetwork/elrond-go-core v1.1.6-0.20211222113209-7f3f1ad307cd
+	github.com/ElrondNetwork/elrond-go-core v1.1.6
 	github.com/ElrondNetwork/elrond-go-logger v1.0.5
 	github.com/ElrondNetwork/elrond-vm-common v1.1.1-0.20210722121034-4894ec636075
 	github.com/elastic/go-elasticsearch/v7 v7.12.0

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,7 @@
 github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6yO+smD0nV23P4bJpmPjTo=
 github.com/ElrondNetwork/elrond-go-core v1.0.1-0.20210721105824-f1bfb549cfce/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
-github.com/ElrondNetwork/elrond-go-core v1.1.5 h1:cq65Z6Rt+SBl1hJx8Ai8Mlai8aCSaLTmaqcu0UTToWc=
-github.com/ElrondNetwork/elrond-go-core v1.1.5/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
-github.com/ElrondNetwork/elrond-go-core v1.1.6-0.20211221104129-9205b629932f h1:dTvRRARVBuKvhbdgHhNT3jOY3BNEwGHA+bjUYgCtb4Q=
-github.com/ElrondNetwork/elrond-go-core v1.1.6-0.20211221104129-9205b629932f/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
+github.com/ElrondNetwork/elrond-go-core v1.1.6-0.20211222084447-ad4e72f6a2ef h1:mgZCCavnY+C7kxMr6uJg/GapQcOPvk8DJjmEplup0bo=
+github.com/ElrondNetwork/elrond-go-core v1.1.6-0.20211222084447-ad4e72f6a2ef/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
 github.com/ElrondNetwork/elrond-go-logger v1.0.4/go.mod h1:e5D+c97lKUfFdAzFX7rrI2Igl/z4Y0RkKYKWyzprTGk=
 github.com/ElrondNetwork/elrond-go-logger v1.0.5 h1:tB/HBvV9IVeCaSrGakX+GLGu7K5UPLv8gA0TNKPOTOU=
 github.com/ElrondNetwork/elrond-go-logger v1.0.5/go.mod h1:cBfgx0ST/CJx8jrxJSC5aiSrvkGzcnF7sK06RD8mFxQ=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6yO+smD0nV23P4bJpmPjTo=
 github.com/ElrondNetwork/elrond-go-core v1.0.1-0.20210721105824-f1bfb549cfce/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
-github.com/ElrondNetwork/elrond-go-core v1.1.6-0.20211222084447-ad4e72f6a2ef h1:mgZCCavnY+C7kxMr6uJg/GapQcOPvk8DJjmEplup0bo=
-github.com/ElrondNetwork/elrond-go-core v1.1.6-0.20211222084447-ad4e72f6a2ef/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
+github.com/ElrondNetwork/elrond-go-core v1.1.6-0.20211222113209-7f3f1ad307cd h1:Og8GXX27Rt2/ozABLlIqgU9/0oVHGokXs9tsteoZ85M=
+github.com/ElrondNetwork/elrond-go-core v1.1.6-0.20211222113209-7f3f1ad307cd/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
 github.com/ElrondNetwork/elrond-go-logger v1.0.4/go.mod h1:e5D+c97lKUfFdAzFX7rrI2Igl/z4Y0RkKYKWyzprTGk=
 github.com/ElrondNetwork/elrond-go-logger v1.0.5 h1:tB/HBvV9IVeCaSrGakX+GLGu7K5UPLv8gA0TNKPOTOU=
 github.com/ElrondNetwork/elrond-go-logger v1.0.5/go.mod h1:cBfgx0ST/CJx8jrxJSC5aiSrvkGzcnF7sK06RD8mFxQ=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6yO+smD0nV23P4bJpmPjTo=
 github.com/ElrondNetwork/elrond-go-core v1.0.1-0.20210721105824-f1bfb549cfce/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
-github.com/ElrondNetwork/elrond-go-core v1.1.6-0.20211222113209-7f3f1ad307cd h1:Og8GXX27Rt2/ozABLlIqgU9/0oVHGokXs9tsteoZ85M=
-github.com/ElrondNetwork/elrond-go-core v1.1.6-0.20211222113209-7f3f1ad307cd/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
+github.com/ElrondNetwork/elrond-go-core v1.1.6 h1:mIbpyCP+yKfmm8HAQjFAtGjJgPvQ7IW7zqqXN7dawbs=
+github.com/ElrondNetwork/elrond-go-core v1.1.6/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
 github.com/ElrondNetwork/elrond-go-logger v1.0.4/go.mod h1:e5D+c97lKUfFdAzFX7rrI2Igl/z4Y0RkKYKWyzprTGk=
 github.com/ElrondNetwork/elrond-go-logger v1.0.5 h1:tB/HBvV9IVeCaSrGakX+GLGu7K5UPLv8gA0TNKPOTOU=
 github.com/ElrondNetwork/elrond-go-logger v1.0.5/go.mod h1:cBfgx0ST/CJx8jrxJSC5aiSrvkGzcnF7sK06RD8mFxQ=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6y
 github.com/ElrondNetwork/elrond-go-core v1.0.1-0.20210721105824-f1bfb549cfce/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
 github.com/ElrondNetwork/elrond-go-core v1.1.5 h1:cq65Z6Rt+SBl1hJx8Ai8Mlai8aCSaLTmaqcu0UTToWc=
 github.com/ElrondNetwork/elrond-go-core v1.1.5/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
+github.com/ElrondNetwork/elrond-go-core v1.1.6-0.20211221104129-9205b629932f h1:dTvRRARVBuKvhbdgHhNT3jOY3BNEwGHA+bjUYgCtb4Q=
+github.com/ElrondNetwork/elrond-go-core v1.1.6-0.20211221104129-9205b629932f/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
 github.com/ElrondNetwork/elrond-go-logger v1.0.4/go.mod h1:e5D+c97lKUfFdAzFX7rrI2Igl/z4Y0RkKYKWyzprTGk=
 github.com/ElrondNetwork/elrond-go-logger v1.0.5 h1:tB/HBvV9IVeCaSrGakX+GLGu7K5UPLv8gA0TNKPOTOU=
 github.com/ElrondNetwork/elrond-go-logger v1.0.5/go.mod h1:cBfgx0ST/CJx8jrxJSC5aiSrvkGzcnF7sK06RD8mFxQ=

--- a/integrationtests/issueToken_test.go
+++ b/integrationtests/issueToken_test.go
@@ -6,7 +6,6 @@ import (
 	indexerdata "github.com/ElrondNetwork/elastic-indexer-go"
 	"github.com/ElrondNetwork/elastic-indexer-go/mock"
 	"github.com/ElrondNetwork/elrond-go-core/core"
-	coreData "github.com/ElrondNetwork/elrond-go-core/data"
 	dataBlock "github.com/ElrondNetwork/elrond-go-core/data/block"
 	"github.com/ElrondNetwork/elrond-go-core/data/indexer"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
@@ -42,15 +41,18 @@ func TestIssueTokenAndTransferOwnership(t *testing.T) {
 	}
 
 	pool := &indexer.Pool{
-		Logs: map[string]coreData.LogHandler{
-			"h1": &transaction.Log{
-				Events: []*transaction.Event{
-					{
-						Address:    []byte("addr"),
-						Identifier: []byte("issueSemiFungible"),
-						Topics:     [][]byte{[]byte("SEMI-abcd"), []byte("semi-token"), []byte("SEMI"), []byte(core.SemiFungibleESDT)},
+		Logs: []indexer.LogData{
+			{
+				TxHash: "h1",
+				LogHandler: &transaction.Log{
+					Events: []*transaction.Event{
+						{
+							Address:    []byte("addr"),
+							Identifier: []byte("issueSemiFungible"),
+							Topics:     [][]byte{[]byte("SEMI-abcd"), []byte("semi-token"), []byte("SEMI"), []byte(core.SemiFungibleESDT)},
+						},
+						nil,
 					},
-					nil,
 				},
 			},
 		},
@@ -67,15 +69,18 @@ func TestIssueTokenAndTransferOwnership(t *testing.T) {
 
 	// transfer ownership
 	pool = &indexer.Pool{
-		Logs: map[string]coreData.LogHandler{
-			"h1": &transaction.Log{
-				Events: []*transaction.Event{
-					{
-						Address:    []byte("addr"),
-						Identifier: []byte("transferOwnership"),
-						Topics:     [][]byte{[]byte("SEMI-abcd"), []byte("semi-token"), []byte("SEMI"), []byte(core.SemiFungibleESDT), []byte("new-address")},
+		Logs: []indexer.LogData{
+			{
+				TxHash: "h1",
+				LogHandler: &transaction.Log{
+					Events: []*transaction.Event{
+						{
+							Address:    []byte("addr"),
+							Identifier: []byte("transferOwnership"),
+							Topics:     [][]byte{[]byte("SEMI-abcd"), []byte("semi-token"), []byte("SEMI"), []byte(core.SemiFungibleESDT), []byte("new-address")},
+						},
+						nil,
 					},
-					nil,
 				},
 			},
 		},

--- a/integrationtests/issueToken_test.go
+++ b/integrationtests/issueToken_test.go
@@ -41,7 +41,7 @@ func TestIssueTokenAndTransferOwnership(t *testing.T) {
 	}
 
 	pool := &indexer.Pool{
-		Logs: []indexer.LogData{
+		Logs: []*indexer.LogData{
 			{
 				TxHash: "h1",
 				LogHandler: &transaction.Log{
@@ -69,7 +69,7 @@ func TestIssueTokenAndTransferOwnership(t *testing.T) {
 
 	// transfer ownership
 	pool = &indexer.Pool{
-		Logs: []indexer.LogData{
+		Logs: []*indexer.LogData{
 			{
 				TxHash: "h1",
 				LogHandler: &transaction.Log{

--- a/integrationtests/issueToken_test.go
+++ b/integrationtests/issueToken_test.go
@@ -6,6 +6,7 @@ import (
 	indexerdata "github.com/ElrondNetwork/elastic-indexer-go"
 	"github.com/ElrondNetwork/elastic-indexer-go/mock"
 	"github.com/ElrondNetwork/elrond-go-core/core"
+	coreData "github.com/ElrondNetwork/elrond-go-core/data"
 	dataBlock "github.com/ElrondNetwork/elrond-go-core/data/block"
 	"github.com/ElrondNetwork/elrond-go-core/data/indexer"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
@@ -41,7 +42,7 @@ func TestIssueTokenAndTransferOwnership(t *testing.T) {
 	}
 
 	pool := &indexer.Pool{
-		Logs: []*indexer.LogData{
+		Logs: []*coreData.LogData{
 			{
 				TxHash: "h1",
 				LogHandler: &transaction.Log{
@@ -69,7 +70,7 @@ func TestIssueTokenAndTransferOwnership(t *testing.T) {
 
 	// transfer ownership
 	pool = &indexer.Pool{
-		Logs: []*indexer.LogData{
+		Logs: []*coreData.LogData{
 			{
 				TxHash: "h1",
 				LogHandler: &transaction.Log{

--- a/process/elasticProcessor.go
+++ b/process/elasticProcessor.go
@@ -498,7 +498,7 @@ func (ei *elasticProcessor) indexTransactionsWithRefund(txsHashRefund map[string
 	return ei.doBulkRequests(elasticIndexer.TransactionsIndex, buffSlice)
 }
 
-func (ei *elasticProcessor) prepareAndIndexLogs(logsAndEvents []*indexer.LogData, timestamp uint64) error {
+func (ei *elasticProcessor) prepareAndIndexLogs(logsAndEvents []*coreData.LogData, timestamp uint64) error {
 	if !ei.isIndexEnabled(elasticIndexer.LogsIndex) {
 		return nil
 	}

--- a/process/elasticProcessor.go
+++ b/process/elasticProcessor.go
@@ -498,7 +498,7 @@ func (ei *elasticProcessor) indexTransactionsWithRefund(txsHashRefund map[string
 	return ei.doBulkRequests(elasticIndexer.TransactionsIndex, buffSlice)
 }
 
-func (ei *elasticProcessor) prepareAndIndexLogs(logsAndEvents map[string]coreData.LogHandler, timestamp uint64) error {
+func (ei *elasticProcessor) prepareAndIndexLogs(logsAndEvents []indexer.LogData, timestamp uint64) error {
 	if !ei.isIndexEnabled(elasticIndexer.LogsIndex) {
 		return nil
 	}

--- a/process/elasticProcessor.go
+++ b/process/elasticProcessor.go
@@ -498,7 +498,7 @@ func (ei *elasticProcessor) indexTransactionsWithRefund(txsHashRefund map[string
 	return ei.doBulkRequests(elasticIndexer.TransactionsIndex, buffSlice)
 }
 
-func (ei *elasticProcessor) prepareAndIndexLogs(logsAndEvents []indexer.LogData, timestamp uint64) error {
+func (ei *elasticProcessor) prepareAndIndexLogs(logsAndEvents []*indexer.LogData, timestamp uint64) error {
 	if !ei.isIndexEnabled(elasticIndexer.LogsIndex) {
 		return nil
 	}

--- a/process/interface.go
+++ b/process/interface.go
@@ -90,9 +90,9 @@ type DBValidatorsHandler interface {
 
 // DBLogsAndEventsHandler defines the actions that a logs and events handler should do
 type DBLogsAndEventsHandler interface {
-	PrepareLogsForDB(logsAndEvents map[string]coreData.LogHandler, timestamp uint64) []*data.Logs
+	PrepareLogsForDB(logsAndEvents []indexer.LogData, timestamp uint64) []*data.Logs
 	ExtractDataFromLogs(
-		logsAndEvents map[string]coreData.LogHandler,
+		logsAndEvents []indexer.LogData,
 		preparedResults *data.PreparedResults,
 		timestamp uint64,
 	) *data.PreparedLogsResults

--- a/process/interface.go
+++ b/process/interface.go
@@ -90,9 +90,9 @@ type DBValidatorsHandler interface {
 
 // DBLogsAndEventsHandler defines the actions that a logs and events handler should do
 type DBLogsAndEventsHandler interface {
-	PrepareLogsForDB(logsAndEvents []indexer.LogData, timestamp uint64) []*data.Logs
+	PrepareLogsForDB(logsAndEvents []*indexer.LogData, timestamp uint64) []*data.Logs
 	ExtractDataFromLogs(
-		logsAndEvents []indexer.LogData,
+		logsAndEvents []*indexer.LogData,
 		preparedResults *data.PreparedResults,
 		timestamp uint64,
 	) *data.PreparedLogsResults

--- a/process/interface.go
+++ b/process/interface.go
@@ -90,9 +90,9 @@ type DBValidatorsHandler interface {
 
 // DBLogsAndEventsHandler defines the actions that a logs and events handler should do
 type DBLogsAndEventsHandler interface {
-	PrepareLogsForDB(logsAndEvents []*indexer.LogData, timestamp uint64) []*data.Logs
+	PrepareLogsForDB(logsAndEvents []*coreData.LogData, timestamp uint64) []*data.Logs
 	ExtractDataFromLogs(
-		logsAndEvents []*indexer.LogData,
+		logsAndEvents []*coreData.LogData,
 		preparedResults *data.PreparedResults,
 		timestamp uint64,
 	) *data.PreparedLogsResults

--- a/process/logsevents/logsAndEventsProcessor.go
+++ b/process/logsevents/logsAndEventsProcessor.go
@@ -103,7 +103,7 @@ func (lep *logsAndEventsProcessor) ExtractDataFromLogs(
 	lep.logsData = newLogsData(timestamp, preparedResults.AlteredAccts, preparedResults.Transactions, preparedResults.ScResults)
 
 	for _, txLog := range logsAndEvents {
-		if check.IfNil(txLog.LogHandler) {
+		if txLog == nil || check.IfNil(txLog.LogHandler) {
 			continue
 		}
 
@@ -188,7 +188,7 @@ func (lep *logsAndEventsProcessor) PrepareLogsForDB(
 	logs := make([]*data.Logs, 0, len(logsAndEvents))
 
 	for _, txLog := range logsAndEvents {
-		if check.IfNil(txLog.LogHandler) {
+		if txLog == nil || check.IfNil(txLog.LogHandler) {
 			continue
 		}
 

--- a/process/logsevents/logsAndEventsProcessor.go
+++ b/process/logsevents/logsAndEventsProcessor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	coreData "github.com/ElrondNetwork/elrond-go-core/data"
+	"github.com/ElrondNetwork/elrond-go-core/data/indexer"
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
 )
@@ -96,19 +97,19 @@ func createEventsProcessors(args *ArgsLogsAndEventsProcessor) []eventsProcessor 
 
 // ExtractDataFromLogs will extract data from the provided logs and events and put in altered addresses
 func (lep *logsAndEventsProcessor) ExtractDataFromLogs(
-	logsAndEvents map[string]coreData.LogHandler,
+	logsAndEvents []indexer.LogData,
 	preparedResults *data.PreparedResults,
 	timestamp uint64,
 ) *data.PreparedLogsResults {
 	lep.logsData = newLogsData(timestamp, preparedResults.AlteredAccts, preparedResults.Transactions, preparedResults.ScResults)
 
-	for logHash, txLog := range logsAndEvents {
-		if check.IfNil(txLog) {
+	for _, txLog := range logsAndEvents {
+		if check.IfNil(txLog.LogHandler) {
 			continue
 		}
 
 		events := txLog.GetLogEvents()
-		lep.processEvents(logHash, txLog.GetAddress(), events)
+		lep.processEvents(txLog.TxHash, txLog.GetAddress(), events)
 	}
 
 	return &data.PreparedLogsResults{
@@ -182,17 +183,17 @@ func (lep *logsAndEventsProcessor) processEvent(logHash string, logAddress []byt
 
 // PrepareLogsForDB will prepare logs for database
 func (lep *logsAndEventsProcessor) PrepareLogsForDB(
-	logsAndEvents map[string]coreData.LogHandler,
+	logsAndEvents []indexer.LogData,
 	timestamp uint64,
 ) []*data.Logs {
 	logs := make([]*data.Logs, 0, len(logsAndEvents))
 
-	for txHash, txLog := range logsAndEvents {
-		if check.IfNil(txLog) {
+	for _, txLog := range logsAndEvents {
+		if check.IfNil(txLog.LogHandler) {
 			continue
 		}
 
-		logs = append(logs, lep.prepareLogsForDB(txHash, txLog, timestamp))
+		logs = append(logs, lep.prepareLogsForDB(txLog.TxHash, txLog, timestamp))
 	}
 
 	return logs

--- a/process/logsevents/logsAndEventsProcessor.go
+++ b/process/logsevents/logsAndEventsProcessor.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	coreData "github.com/ElrondNetwork/elrond-go-core/data"
-	"github.com/ElrondNetwork/elrond-go-core/data/indexer"
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
 	"github.com/ElrondNetwork/elrond-go-core/marshal"
 )
@@ -97,7 +96,7 @@ func createEventsProcessors(args *ArgsLogsAndEventsProcessor) []eventsProcessor 
 
 // ExtractDataFromLogs will extract data from the provided logs and events and put in altered addresses
 func (lep *logsAndEventsProcessor) ExtractDataFromLogs(
-	logsAndEvents []*indexer.LogData,
+	logsAndEvents []*coreData.LogData,
 	preparedResults *data.PreparedResults,
 	timestamp uint64,
 ) *data.PreparedLogsResults {
@@ -183,7 +182,7 @@ func (lep *logsAndEventsProcessor) processEvent(logHash string, logAddress []byt
 
 // PrepareLogsForDB will prepare logs for database
 func (lep *logsAndEventsProcessor) PrepareLogsForDB(
-	logsAndEvents []*indexer.LogData,
+	logsAndEvents []*coreData.LogData,
 	timestamp uint64,
 ) []*data.Logs {
 	logs := make([]*data.Logs, 0, len(logsAndEvents))

--- a/process/logsevents/logsAndEventsProcessor.go
+++ b/process/logsevents/logsAndEventsProcessor.go
@@ -97,7 +97,7 @@ func createEventsProcessors(args *ArgsLogsAndEventsProcessor) []eventsProcessor 
 
 // ExtractDataFromLogs will extract data from the provided logs and events and put in altered addresses
 func (lep *logsAndEventsProcessor) ExtractDataFromLogs(
-	logsAndEvents []indexer.LogData,
+	logsAndEvents []*indexer.LogData,
 	preparedResults *data.PreparedResults,
 	timestamp uint64,
 ) *data.PreparedLogsResults {
@@ -108,8 +108,8 @@ func (lep *logsAndEventsProcessor) ExtractDataFromLogs(
 			continue
 		}
 
-		events := txLog.GetLogEvents()
-		lep.processEvents(txLog.TxHash, txLog.GetAddress(), events)
+		events := txLog.LogHandler.GetLogEvents()
+		lep.processEvents(txLog.TxHash, txLog.LogHandler.GetAddress(), events)
 	}
 
 	return &data.PreparedLogsResults{
@@ -183,7 +183,7 @@ func (lep *logsAndEventsProcessor) processEvent(logHash string, logAddress []byt
 
 // PrepareLogsForDB will prepare logs for database
 func (lep *logsAndEventsProcessor) PrepareLogsForDB(
-	logsAndEvents []indexer.LogData,
+	logsAndEvents []*indexer.LogData,
 	timestamp uint64,
 ) []*data.Logs {
 	logs := make([]*data.Logs, 0, len(logsAndEvents))
@@ -193,7 +193,7 @@ func (lep *logsAndEventsProcessor) PrepareLogsForDB(
 			continue
 		}
 
-		logs = append(logs, lep.prepareLogsForDB(txLog.TxHash, txLog, timestamp))
+		logs = append(logs, lep.prepareLogsForDB(txLog.TxHash, txLog.LogHandler, timestamp))
 	}
 
 	return logs

--- a/process/logsevents/logsAndEventsProcessor_test.go
+++ b/process/logsevents/logsAndEventsProcessor_test.go
@@ -125,9 +125,9 @@ func TestLogsAndEventsProcessor_ExtractDataFromLogsAndPutInAltered(t *testing.T)
 		},
 	}
 
-	logsAndEventsSlice := make([]indexer.LogData, 0)
+	logsAndEventsSlice := make([]*indexer.LogData, 0)
 	for hash, val := range logsAndEvents {
-		logsAndEventsSlice = append(logsAndEventsSlice, indexer.LogData{
+		logsAndEventsSlice = append(logsAndEventsSlice, &indexer.LogData{
 			TxHash:     hash,
 			LogHandler: val,
 		})
@@ -210,9 +210,9 @@ func TestLogsAndEventsProcessor_PrepareLogsForDB(t *testing.T) {
 		},
 	}
 
-	logsAndEventsSlice := make([]indexer.LogData, 0)
+	logsAndEventsSlice := make([]*indexer.LogData, 0)
 	for hash, val := range logsAndEvents {
-		logsAndEventsSlice = append(logsAndEventsSlice, indexer.LogData{
+		logsAndEventsSlice = append(logsAndEventsSlice, &indexer.LogData{
 			TxHash:     hash,
 			LogHandler: val,
 		})

--- a/process/logsevents/logsAndEventsProcessor_test.go
+++ b/process/logsevents/logsAndEventsProcessor_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ElrondNetwork/elastic-indexer-go/mock"
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	coreData "github.com/ElrondNetwork/elrond-go-core/data"
+	"github.com/ElrondNetwork/elrond-go-core/data/indexer"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/stretchr/testify/require"
 )
@@ -124,6 +125,14 @@ func TestLogsAndEventsProcessor_ExtractDataFromLogsAndPutInAltered(t *testing.T)
 		},
 	}
 
+	logsAndEventsSlice := make([]indexer.LogData, 0)
+	for hash, val := range logsAndEvents {
+		logsAndEventsSlice = append(logsAndEventsSlice, indexer.LogData{
+			TxHash:     hash,
+			LogHandler: val,
+		})
+	}
+
 	altered := data.NewAlteredAccounts()
 	res := &data.PreparedResults{
 		Transactions: []*data.Transaction{
@@ -147,7 +156,7 @@ func TestLogsAndEventsProcessor_ExtractDataFromLogsAndPutInAltered(t *testing.T)
 	}
 	proc, _ := NewLogsAndEventsProcessor(args)
 
-	resLogs := proc.ExtractDataFromLogs(logsAndEvents, res, 1000)
+	resLogs := proc.ExtractDataFromLogs(logsAndEventsSlice, res, 1000)
 	require.NotNil(t, resLogs.Tokens)
 	require.NotNil(t, resLogs.TagsCount)
 	require.True(t, res.Transactions[0].HasOperations)
@@ -201,10 +210,18 @@ func TestLogsAndEventsProcessor_PrepareLogsForDB(t *testing.T) {
 		},
 	}
 
+	logsAndEventsSlice := make([]indexer.LogData, 0)
+	for hash, val := range logsAndEvents {
+		logsAndEventsSlice = append(logsAndEventsSlice, indexer.LogData{
+			TxHash:     hash,
+			LogHandler: val,
+		})
+	}
+
 	args := createMockArgs()
 	proc, _ := NewLogsAndEventsProcessor(args)
 
-	logsDB := proc.PrepareLogsForDB(logsAndEvents, 1234)
+	logsDB := proc.PrepareLogsForDB(logsAndEventsSlice, 1234)
 	require.Equal(t, &data.Logs{
 		ID:        "747848617368",
 		Address:   "61646472657373",

--- a/process/logsevents/logsAndEventsProcessor_test.go
+++ b/process/logsevents/logsAndEventsProcessor_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ElrondNetwork/elastic-indexer-go/mock"
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	coreData "github.com/ElrondNetwork/elrond-go-core/data"
-	"github.com/ElrondNetwork/elrond-go-core/data/indexer"
 	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
 	"github.com/stretchr/testify/require"
 )
@@ -125,9 +124,9 @@ func TestLogsAndEventsProcessor_ExtractDataFromLogsAndPutInAltered(t *testing.T)
 		},
 	}
 
-	logsAndEventsSlice := make([]*indexer.LogData, 0)
+	logsAndEventsSlice := make([]*coreData.LogData, 0)
 	for hash, val := range logsAndEvents {
-		logsAndEventsSlice = append(logsAndEventsSlice, &indexer.LogData{
+		logsAndEventsSlice = append(logsAndEventsSlice, &coreData.LogData{
 			TxHash:     hash,
 			LogHandler: val,
 		})
@@ -210,9 +209,9 @@ func TestLogsAndEventsProcessor_PrepareLogsForDB(t *testing.T) {
 		},
 	}
 
-	logsAndEventsSlice := make([]*indexer.LogData, 0)
+	logsAndEventsSlice := make([]*coreData.LogData, 0)
 	for hash, val := range logsAndEvents {
-		logsAndEventsSlice = append(logsAndEventsSlice, &indexer.LogData{
+		logsAndEventsSlice = append(logsAndEventsSlice, &coreData.LogData{
 			TxHash:     hash,
 			LogHandler: val,
 		})


### PR DESCRIPTION
adapt to logs and events changes -> use slice instead of map in order to maintain the order