### PR TITLE
Improves indexer

### DIFF
--- a/converters/tokenMetaData.go
+++ b/converters/tokenMetaData.go
@@ -1,10 +1,16 @@
 package converters
 
 import (
+	"strings"
+
 	"github.com/ElrondNetwork/elastic-indexer-go/data"
 	"github.com/ElrondNetwork/elrond-go-core/core"
 	"github.com/ElrondNetwork/elrond-go-core/core/check"
 	"github.com/ElrondNetwork/elrond-go-core/data/esdt"
+)
+
+const (
+	ipfsURL = "https://ipfs.io/ipfs/"
 )
 
 // PrepareTokenMetaData will prepare the token metadata in a friendly format for database
@@ -23,15 +29,16 @@ func PrepareTokenMetaData(pubKeyConverter core.PubkeyConverter, esdtInfo *esdt.E
 	}
 
 	return &data.TokenMetaData{
-		Name:         string(esdtInfo.TokenMetaData.Name),
-		Creator:      creatorStr,
-		Royalties:    esdtInfo.TokenMetaData.Royalties,
-		Hash:         esdtInfo.TokenMetaData.Hash,
-		URIs:         esdtInfo.TokenMetaData.URIs,
-		Attributes:   esdtInfo.TokenMetaData.Attributes,
-		Tags:         ExtractTagsFromAttributes(esdtInfo.TokenMetaData.Attributes),
-		MetaData:     ExtractMetaDataFromAttributes(esdtInfo.TokenMetaData.Attributes),
-		NonEmptyURIs: nonEmptyURIs(esdtInfo.TokenMetaData.URIs),
+		Name:               string(esdtInfo.TokenMetaData.Name),
+		Creator:            creatorStr,
+		Royalties:          esdtInfo.TokenMetaData.Royalties,
+		Hash:               esdtInfo.TokenMetaData.Hash,
+		URIs:               esdtInfo.TokenMetaData.URIs,
+		Attributes:         esdtInfo.TokenMetaData.Attributes,
+		Tags:               ExtractTagsFromAttributes(esdtInfo.TokenMetaData.Attributes),
+		MetaData:           ExtractMetaDataFromAttributes(esdtInfo.TokenMetaData.Attributes),
+		NonEmptyURIs:       nonEmptyURIs(esdtInfo.TokenMetaData.URIs),
+		WhiteListedStorage: whiteListedStorage(esdtInfo.TokenMetaData.URIs),
 	}
 }
 
@@ -43,4 +50,12 @@ func nonEmptyURIs(uris [][]byte) bool {
 	}
 
 	return false
+}
+
+func whiteListedStorage(uris [][]byte) bool {
+	if len(uris) == 0 {
+		return false
+	}
+
+	return strings.HasPrefix(string(uris[0]), ipfsURL)
 }

--- a/converters/tokenMetaData_test.go
+++ b/converters/tokenMetaData_test.go
@@ -16,15 +16,16 @@ func TestPrepareTokenMetaData(t *testing.T) {
 	require.Nil(t, PrepareTokenMetaData(&mock.PubkeyConverterMock{}, nil))
 
 	expectedTokenMetaData := &data.TokenMetaData{
-		Name:         "token",
-		Creator:      "63726561746f72",
-		Royalties:    0,
-		Hash:         []byte("hash"),
-		URIs:         [][]byte{[]byte("uri")},
-		Attributes:   []byte("tags:test,free,fun;description:This is a test description for an awesome nft;metadata:metadata-test"),
-		Tags:         []string{"test", "free", "fun"},
-		MetaData:     "metadata-test",
-		NonEmptyURIs: true,
+		Name:               "token",
+		Creator:            "63726561746f72",
+		Royalties:          0,
+		Hash:               []byte("hash"),
+		URIs:               [][]byte{[]byte("https://ipfs.io/ipfs/something"), []byte("uri")},
+		Attributes:         []byte("tags:test,free,fun;description:This is a test description for an awesome nft;metadata:metadata-test"),
+		Tags:               []string{"test", "free", "fun"},
+		MetaData:           "metadata-test",
+		NonEmptyURIs:       true,
+		WhiteListedStorage: true,
 	}
 
 	result := PrepareTokenMetaData(&mock.PubkeyConverterMock{}, &esdt.ESDigitalToken{
@@ -34,7 +35,7 @@ func TestPrepareTokenMetaData(t *testing.T) {
 			Creator:    []byte("creator"),
 			Royalties:  0,
 			Hash:       []byte("hash"),
-			URIs:       [][]byte{[]byte("uri")},
+			URIs:       [][]byte{[]byte(ipfsURL + "something"), []byte("uri")},
 			Attributes: []byte("tags:test,free,fun;description:This is a test description for an awesome nft;metadata:metadata-test"),
 		},
 	})

--- a/data/account.go
+++ b/data/account.go
@@ -25,15 +25,16 @@ type AccountInfo struct {
 
 // TokenMetaData holds data about a token metadata
 type TokenMetaData struct {
-	Name         string   `json:"name,omitempty"`
-	Creator      string   `json:"creator,omitempty"`
-	Royalties    uint32   `json:"royalties,omitempty"`
-	Hash         []byte   `json:"hash,omitempty"`
-	URIs         [][]byte `json:"uris,omitempty"`
-	Tags         []string `json:"tags,omitempty"`
-	Attributes   []byte   `json:"attributes,omitempty"`
-	MetaData     string   `json:"metadata,omitempty"`
-	NonEmptyURIs bool     `json:"nonEmptyURIs"`
+	Name               string   `json:"name,omitempty"`
+	Creator            string   `json:"creator,omitempty"`
+	Royalties          uint32   `json:"royalties,omitempty"`
+	Hash               []byte   `json:"hash,omitempty"`
+	URIs               [][]byte `json:"uris,omitempty"`
+	Tags               []string `json:"tags,omitempty"`
+	Attributes         []byte   `json:"attributes,omitempty"`
+	MetaData           string   `json:"metadata,omitempty"`
+	NonEmptyURIs       bool     `json:"nonEmptyURIs"`
+	WhiteListedStorage bool     `json:"whiteListedStorage"`
 }
 
 // AccountBalanceHistory represents an entry in the user accounts balances history

--- a/data/block.go
+++ b/data/block.go
@@ -24,6 +24,7 @@ type Block struct {
 	PrevHash              string          `json:"prevHash"`
 	ShardID               uint32          `json:"shardId"`
 	TxCount               uint32          `json:"txCount"`
+	NotarizedTxsCount     uint32          `json:"notarizedTxsCount"`
 	AccumulatedFees       string          `json:"accumulatedFees"`
 	DeveloperFees         string          `json:"developerFees"`
 	EpochStartBlock       bool            `json:"epochStartBlock"`

--- a/data/logs.go
+++ b/data/logs.go
@@ -16,6 +16,7 @@ type Event struct {
 	Identifier string   `json:"identifier"`
 	Topics     [][]byte `json:"topics"`
 	Data       []byte   `json:"data"`
+	Order      int      `json:"order"`
 }
 
 // PreparedLogsResults is the DTO that holds all the results after processing

--- a/process/accounts/serialize_test.go
+++ b/process/accounts/serialize_test.go
@@ -28,7 +28,7 @@ func TestSerializeNFTCreateInfo(t *testing.T) {
 	require.Equal(t, 1, len(res))
 
 	expectedRes := `{ "index" : { "_id" : "my-token-001-0f" } }
-{"identifier":"my-token-001-0f","token":"my-token-0001","type":"NonFungibleESDT","data":{"creator":"010102","nonEmptyURIs":false}}
+{"identifier":"my-token-001-0f","token":"my-token-0001","type":"NonFungibleESDT","data":{"creator":"010102","nonEmptyURIs":false,"whiteListedStorage":false}}
 `
 	require.Equal(t, expectedRes, res[0].String())
 }
@@ -143,7 +143,7 @@ func TestSerializeAccountsNFTWithMedaData(t *testing.T) {
 	require.Equal(t, 1, len(res))
 
 	expectedRes := `{ "index" : { "_id" : "addr1-token-0001-16" } }
-{"address":"addr1","nonce":1,"balance":"10000000000000","balanceNum":1,"token":"token-0001","identifier":"token-0001-5","tokenNonce":22,"properties":"000","data":{"name":"nft","creator":"010101","royalties":1,"hash":"aGFzaA==","uris":["dXJp"],"tags":["test","free","fun"],"attributes":"dGFnczp0ZXN0LGZyZWUsZnVuO2Rlc2NyaXB0aW9uOlRoaXMgaXMgYSB0ZXN0IGRlc2NyaXB0aW9uIGZvciBhbiBhd2Vzb21lIG5mdA==","metadata":"metadata-test","nonEmptyURIs":true}}
+{"address":"addr1","nonce":1,"balance":"10000000000000","balanceNum":1,"token":"token-0001","identifier":"token-0001-5","tokenNonce":22,"properties":"000","data":{"name":"nft","creator":"010101","royalties":1,"hash":"aGFzaA==","uris":["dXJp"],"tags":["test","free","fun"],"attributes":"dGFnczp0ZXN0LGZyZWUsZnVuO2Rlc2NyaXB0aW9uOlRoaXMgaXMgYSB0ZXN0IGRlc2NyaXB0aW9uIGZvciBhbiBhd2Vzb21lIG5mdA==","metadata":"metadata-test","nonEmptyURIs":true,"whiteListedStorage":false}}
 `
 	require.Equal(t, expectedRes, res[0].String())
 }

--- a/process/block/blockProcessor_test.go
+++ b/process/block/blockProcessor_test.go
@@ -160,6 +160,7 @@ func TestBlockProcessor_PrepareBlockForDBEpochStartMeta(t *testing.T) {
 	bp, _ := NewBlockProcessor(&mock.HasherMock{}, &mock.MarshalizerMock{})
 
 	dbBlock, err := bp.PrepareBlockForDB(&dataBlock.MetaBlock{
+		TxCount: 1000,
 		EpochStart: dataBlock.EpochStart{
 			LastFinalizedHeaders: []dataBlock.EpochStartShardData{{}},
 			Economics: dataBlock.Economics{
@@ -173,25 +174,32 @@ func TestBlockProcessor_PrepareBlockForDBEpochStartMeta(t *testing.T) {
 				PrevEpochStartHash:               []byte("prevEpoch"),
 			},
 		},
+		MiniBlockHeaders: []dataBlock.MiniBlockHeader{
+			{
+				TxCount: 50,
+			},
+			{
+				TxCount: 120,
+			},
+		},
 	}, nil, &dataBlock.Body{}, nil, coreIndexerData.HeaderGasConsumption{}, 0)
 	require.Equal(t, nil, err)
 	require.Equal(t, &data.Block{
 		Nonce:                 0,
 		Round:                 0,
 		Epoch:                 0,
-		Hash:                  "11cb2a3a28522a11ae646a93aa4d50f87194cead7d6edeb333d502349407b61d",
+		Hash:                  "ae3fe1896d1ecc5fa685a8042b7410378c4ea8451b451f8ade319d7c0b7976e6",
 		MiniBlocksHashes:      []string{},
 		NotarizedBlocksHashes: nil,
 		Proposer:              0,
 		Validators:            nil,
 		PubKeyBitmap:          "",
-		Size:                  345,
+		Size:                  388,
 		SizeTxs:               0,
 		Timestamp:             0,
 		StateRootHash:         "",
 		PrevHash:              "",
 		ShardID:               core.MetachainShardId,
-		TxCount:               0,
 		EpochStartBlock:       true,
 		SearchOrder:           0x3f2,
 		EpochStartInfo: &data.EpochStartInfo{
@@ -204,5 +212,7 @@ func TestBlockProcessor_PrepareBlockForDBEpochStartMeta(t *testing.T) {
 			PrevEpochStartRound:              222,
 			PrevEpochStartHash:               "7072657645706f6368",
 		},
+		NotarizedTxsCount: 830,
+		TxCount:           170,
 	}, dbBlock)
 }

--- a/process/block/serialize_test.go
+++ b/process/block/serialize_test.go
@@ -29,7 +29,7 @@ func TestBlockProcessor_SerializeBlock(t *testing.T) {
 
 	buff, err := bp.SerializeBlock(&data.Block{Nonce: 1})
 	require.Nil(t, err)
-	require.Equal(t, `{"nonce":1,"round":0,"epoch":0,"miniBlocksHashes":null,"notarizedBlocksHashes":null,"proposer":0,"validators":null,"pubKeyBitmap":"","size":0,"sizeTxs":0,"timestamp":0,"stateRootHash":"","prevHash":"","shardId":0,"txCount":0,"accumulatedFees":"","developerFees":"","epochStartBlock":false,"searchOrder":0,"gasProvided":0,"gasRefunded":0,"gasPenalized":0,"maxGasLimit":0}`, buff.String())
+	require.Equal(t, `{"nonce":1,"round":0,"epoch":0,"miniBlocksHashes":null,"notarizedBlocksHashes":null,"proposer":0,"validators":null,"pubKeyBitmap":"","size":0,"sizeTxs":0,"timestamp":0,"stateRootHash":"","prevHash":"","shardId":0,"txCount":0,"notarizedTxsCount":0,"accumulatedFees":"","developerFees":"","epochStartBlock":false,"searchOrder":0,"gasProvided":0,"gasRefunded":0,"gasPenalized":0,"maxGasLimit":0}`, buff.String())
 }
 
 func TestBlockProcessor_SerializeEpochInfoDataErrors(t *testing.T) {
@@ -70,6 +70,8 @@ func TestBlockProcessor_SerializeBlockEpochStartMeta(t *testing.T) {
 		NotarizedBlocksHashes: []string{"notarized1"},
 		Proposer:              5,
 		Validators:            []uint64{0, 1, 2, 3, 4, 5},
+		TxCount:               100,
+		NotarizedTxsCount:     120,
 		PubKeyBitmap:          "00000110",
 		Timestamp:             123456,
 		StateRootHash:         "stateHash",
@@ -93,5 +95,5 @@ func TestBlockProcessor_SerializeBlockEpochStartMeta(t *testing.T) {
 		},
 	})
 	require.Nil(t, err)
-	require.Equal(t, `{"nonce":1,"round":2,"epoch":3,"miniBlocksHashes":["mb1Hash","mbHash2"],"notarizedBlocksHashes":["notarized1"],"proposer":5,"validators":[0,1,2,3,4,5],"pubKeyBitmap":"00000110","size":345,"sizeTxs":0,"timestamp":123456,"stateRootHash":"stateHash","prevHash":"prevHash","shardId":4294967295,"txCount":0,"accumulatedFees":"1000","developerFees":"50","epochStartBlock":true,"searchOrder":1010,"epochStartInfo":{"totalSupply":"100","totalToDistribute":"55","totalNewlyMinted":"20","rewardsPerBlock":"15","rewardsForProtocolSustainability":"2","nodePrice":"10","prevEpochStartRound":222,"prevEpochStartHash":"7072657645706f6368"},"gasProvided":0,"gasRefunded":0,"gasPenalized":0,"maxGasLimit":0}`, buff.String())
+	require.Equal(t, `{"nonce":1,"round":2,"epoch":3,"miniBlocksHashes":["mb1Hash","mbHash2"],"notarizedBlocksHashes":["notarized1"],"proposer":5,"validators":[0,1,2,3,4,5],"pubKeyBitmap":"00000110","size":345,"sizeTxs":0,"timestamp":123456,"stateRootHash":"stateHash","prevHash":"prevHash","shardId":4294967295,"txCount":100,"notarizedTxsCount":120,"accumulatedFees":"1000","developerFees":"50","epochStartBlock":true,"searchOrder":1010,"epochStartInfo":{"totalSupply":"100","totalToDistribute":"55","totalNewlyMinted":"20","rewardsPerBlock":"15","rewardsForProtocolSustainability":"2","nodePrice":"10","prevEpochStartRound":222,"prevEpochStartHash":"7072657645706f6368"},"gasProvided":0,"gasRefunded":0,"gasPenalized":0,"maxGasLimit":0}`, buff.String())
 }

--- a/process/logsevents/logsAndEventsProcessor.go
+++ b/process/logsevents/logsAndEventsProcessor.go
@@ -211,7 +211,7 @@ func (lep *logsAndEventsProcessor) prepareLogsForDB(
 		Events:    make([]*data.Event, 0, len(events)),
 	}
 
-	for _, event := range events {
+	for idx, event := range events {
 		if check.IfNil(event) {
 			continue
 		}
@@ -221,6 +221,7 @@ func (lep *logsAndEventsProcessor) prepareLogsForDB(
 			Identifier: string(event.GetIdentifier()),
 			Topics:     event.GetTopics(),
 			Data:       event.GetData(),
+			Order:      idx,
 		})
 	}
 

--- a/process/logsevents/serialize_test.go
+++ b/process/logsevents/serialize_test.go
@@ -25,6 +25,7 @@ func TestLogsAndEventsProcessor_SerializeLogs(t *testing.T) {
 					Identifier: core.BuiltInFunctionESDTNFTTransfer,
 					Topics:     [][]byte{[]byte("my-token"), big.NewInt(0).SetUint64(1).Bytes(), []byte("receiver")},
 					Data:       []byte("data"),
+					Order:      0,
 				},
 			},
 		},
@@ -34,7 +35,7 @@ func TestLogsAndEventsProcessor_SerializeLogs(t *testing.T) {
 	require.Nil(t, err)
 
 	expectedRes := `{ "index" : { "_id" : "747848617368" } }
-{"address":"61646472657373","events":[{"address":"61646472","identifier":"ESDTNFTTransfer","topics":["bXktdG9rZW4=","AQ==","cmVjZWl2ZXI="],"data":"ZGF0YQ=="}],"timestamp":1234}
+{"address":"61646472657373","events":[{"address":"61646472","identifier":"ESDTNFTTransfer","topics":["bXktdG9rZW4=","AQ==","cmVjZWl2ZXI="],"data":"ZGF0YQ==","order":0}],"timestamp":1234}
 `
 	require.Equal(t, expectedRes, res[0].String())
 }


### PR DESCRIPTION
Improves:
- Added `whiteListedStorage` flag for NFT's ( a NFT is whitelisted if is stored in IPFS)
- Added an extra field `notarizedTxsCount` for the `metachain` block