### PR TITLE
Timestamp in accounts esdt

### DIFF
--- a/data/account.go
+++ b/data/account.go
@@ -21,6 +21,7 @@ type AccountInfo struct {
 	TotalBalanceWithStake    string         `json:"totalBalanceWithStake,omitempty"`
 	TotalBalanceWithStakeNum float64        `json:"totalBalanceWithStakeNum,omitempty"`
 	Data                     *TokenMetaData `json:"data,omitempty"`
+	Timestamp                time.Duration  `json:"timestamp,omitempty"`
 }
 
 // TokenMetaData holds data about a token metadata

--- a/mock/dbAccountsHandlerStub.go
+++ b/mock/dbAccountsHandlerStub.go
@@ -23,7 +23,7 @@ func (dba *DBAccountsHandlerStub) PrepareRegularAccountsMap(_ []*data.Account) m
 }
 
 // PrepareAccountsMapESDT -
-func (dba *DBAccountsHandlerStub) PrepareAccountsMapESDT(_ []*data.AccountESDT) map[string]*data.AccountInfo {
+func (dba *DBAccountsHandlerStub) PrepareAccountsMapESDT(_ uint64, _ []*data.AccountESDT) map[string]*data.AccountInfo {
 	return nil
 }
 

--- a/process/accounts/accountsProcessor.go
+++ b/process/accounts/accountsProcessor.go
@@ -164,6 +164,7 @@ func (ap *accountsProcessor) PrepareRegularAccountsMap(accounts []*data.Account)
 
 // PrepareAccountsMapESDT will prepare a map of accounts with ESDT tokens
 func (ap *accountsProcessor) PrepareAccountsMapESDT(
+	timestamp uint64,
 	accounts []*data.AccountESDT,
 ) map[string]*data.AccountInfo {
 	accountsESDTMap := make(map[string]*data.AccountInfo)
@@ -188,6 +189,7 @@ func (ap *accountsProcessor) PrepareAccountsMapESDT(
 			IsSender:        accountESDT.IsSender,
 			IsSmartContract: core.IsSmartContractAddress(accountESDT.Account.AddressBytes()),
 			Data:            tokenMetaData,
+			Timestamp:       time.Duration(timestamp),
 		}
 
 		keyInMap := fmt.Sprintf("%s-%s-%d", acc.Address, acc.TokenName, accountESDT.NFTNonce)

--- a/process/accounts/accountsProcessor_test.go
+++ b/process/accounts/accountsProcessor_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"math/big"
 	"testing"
+	"time"
 
 	indexer "github.com/ElrondNetwork/elastic-indexer-go"
 	"github.com/ElrondNetwork/elastic-indexer-go/converters"
@@ -373,7 +374,7 @@ func TestAccountsProcessor_PrepareAccountsMapESDT(t *testing.T) {
 		{Account: mockAccount, TokenIdentifier: "token", IsNFTOperation: true, NFTNonce: 15},
 		{Account: mockAccount, TokenIdentifier: "token", IsNFTOperation: true, NFTNonce: 16},
 	}
-	res := ap.PrepareAccountsMapESDT(accountsESDT)
+	res := ap.PrepareAccountsMapESDT(123, accountsESDT)
 	require.Len(t, res, 2)
 
 	require.Equal(t, &data.AccountInfo{
@@ -387,6 +388,7 @@ func TestAccountsProcessor_PrepareAccountsMapESDT(t *testing.T) {
 		Data: &data.TokenMetaData{
 			Creator: "63726561746f72",
 		},
+		Timestamp: time.Duration(123),
 	}, res[hex.EncodeToString([]byte(addr))+"-token-15"])
 
 	require.Equal(t, &data.AccountInfo{
@@ -400,6 +402,7 @@ func TestAccountsProcessor_PrepareAccountsMapESDT(t *testing.T) {
 		Data: &data.TokenMetaData{
 			Creator: "63726561746f72",
 		},
+		Timestamp: time.Duration(123),
 	}, res[hex.EncodeToString([]byte(addr))+"-token-16"])
 }
 

--- a/process/accounts/serialize_test.go
+++ b/process/accounts/serialize_test.go
@@ -71,6 +71,7 @@ func TestSerializeAccountsESDTNonceZero(t *testing.T) {
 			TokenNonce: 0,
 			Balance:    "10000000000000",
 			BalanceNum: 1,
+			Timestamp:  123,
 		},
 	}
 
@@ -79,7 +80,7 @@ func TestSerializeAccountsESDTNonceZero(t *testing.T) {
 	require.Equal(t, 1, len(res))
 
 	expectedRes := `{ "index" : { "_id" : "addr1-token-abcd-00" } }
-{"address":"addr1","nonce":1,"balance":"10000000000000","balanceNum":1,"token":"token-abcd","properties":"000"}
+{"address":"addr1","nonce":1,"balance":"10000000000000","balanceNum":1,"token":"token-abcd","properties":"000","timestamp":123}
 `
 	require.Equal(t, expectedRes, res[0].String())
 }

--- a/process/elasticProcessor.go
+++ b/process/elasticProcessor.go
@@ -617,7 +617,7 @@ func (ei *elasticProcessor) saveAccountsESDT(
 	wrappedAccounts []*data.AccountESDT,
 	updatesNFTsData []*data.NFTDataUpdate,
 ) error {
-	accountsESDTMap := ei.accountsProc.PrepareAccountsMapESDT(wrappedAccounts)
+	accountsESDTMap := ei.accountsProc.PrepareAccountsMapESDT(timestamp, wrappedAccounts)
 
 	err := ei.indexAccountsESDT(accountsESDTMap, updatesNFTsData)
 	if err != nil {

--- a/process/interface.go
+++ b/process/interface.go
@@ -29,7 +29,7 @@ type DatabaseClientHandler interface {
 type DBAccountHandler interface {
 	GetAccounts(alteredAccounts data.AlteredAccountsHandler) ([]*data.Account, []*data.AccountESDT)
 	PrepareRegularAccountsMap(accounts []*data.Account) map[string]*data.AccountInfo
-	PrepareAccountsMapESDT(accounts []*data.AccountESDT) map[string]*data.AccountInfo
+	PrepareAccountsMapESDT(timestamp uint64, accounts []*data.AccountESDT) map[string]*data.AccountInfo
 	PrepareAccountsHistory(timestamp uint64, accounts map[string]*data.AccountInfo) map[string]*data.AccountBalanceHistory
 
 	SerializeAccountsHistory(accounts map[string]*data.AccountBalanceHistory) ([]*bytes.Buffer, error)

--- a/templates/noKibana/accountsESDT.go
+++ b/templates/noKibana/accountsESDT.go
@@ -37,6 +37,10 @@ var AccountsESDT = Object{
 			"tokenNonce": Object{
 				"type": "double",
 			},
+			"timestamp": Object{
+				"type":   "date",
+				"format": "epoch_second",
+			},
 		},
 	},
 }

--- a/templates/withKibana/accountsESDT.go
+++ b/templates/withKibana/accountsESDT.go
@@ -37,6 +37,10 @@ var AccountsESDT = Object{
 			"tokenNonce": Object{
 				"type": "double",
 			},
+			"timestamp": Object{
+				"type":   "date",
+				"format": "epoch_second",
+			},
 		},
 	},
 }

--- a/tools/indices-creator/cmd/indices-creator/config/noKibana/accountsesdt.json
+++ b/tools/indices-creator/cmd/indices-creator/config/noKibana/accountsesdt.json
@@ -29,7 +29,11 @@
 			},
 			"tokenNonce": {
 				"type": "double"
-			}
+			},
+           "timestamp": {
+             "type": "date",
+             "format": "epoch_second"
+           }
 		}
 	},
 	"settings": {

--- a/tools/indices-creator/cmd/indices-creator/config/withKibana/accountsesdt.json
+++ b/tools/indices-creator/cmd/indices-creator/config/withKibana/accountsesdt.json
@@ -29,6 +29,10 @@
 			},
 			"tokenNonce": {
 				"type": "double"
+			},
+			"timestamp": {
+				"type": "date",
+				"format": "epoch_second"
 			}
 		}
 	},


### PR DESCRIPTION
- Added a new field in the `accountsest` index. This new field will keep the block timestamp when the document was inserted.