### PR TITLE
Refactor how bulk requests are made

### DIFF
--- a/client/elasticClient.go
+++ b/client/elasticClient.go
@@ -106,7 +106,15 @@ func (ec *elasticClient) DoRequest(req *esapi.IndexRequest) error {
 func (ec *elasticClient) DoBulkRequest(buff *bytes.Buffer, index string) error {
 	reader := bytes.NewReader(buff.Bytes())
 
-	res, err := ec.es.Bulk(reader, ec.es.Bulk.WithIndex(index))
+	options := make([]func(*esapi.BulkRequest), 0)
+	if index != "" {
+		options = append(options, ec.es.Bulk.WithIndex(index))
+	}
+
+	res, err := ec.es.Bulk(
+		reader,
+		options...,
+	)
 	if err != nil {
 		log.Warn("elasticClient.DoBulkRequest",
 			"indexer do bulk request no response", err.Error())

--- a/converters/tokenMetaData.go
+++ b/converters/tokenMetaData.go
@@ -76,14 +76,14 @@ func whiteListedStorage(uris [][]byte) bool {
 }
 
 // PrepareNFTUpdateData will prepare nfts update data
-func PrepareNFTUpdateData(buffSlice *data.BufferSlice, updateNFTData []*data.NFTDataUpdate, accountESDT bool) error {
+func PrepareNFTUpdateData(buffSlice *data.BufferSlice, updateNFTData []*data.NFTDataUpdate, accountESDT bool, index string) error {
 	for _, nftUpdate := range updateNFTData {
 		id := nftUpdate.Identifier
 		if accountESDT {
 			id = fmt.Sprintf("%s-%s", nftUpdate.Address, nftUpdate.Identifier)
 		}
 
-		metaData := []byte(fmt.Sprintf(`{"update":{"_id":"%s", "_type": "_doc"}}%s`, id, "\n"))
+		metaData := []byte(fmt.Sprintf(`{"update":{ "_index":"%s","_id":"%s", "_type": "_doc"}}%s`, index, id, "\n"))
 		base64Attr := base64.StdEncoding.EncodeToString(nftUpdate.NewAttributes)
 		serializedData := []byte(fmt.Sprintf(`{"script": {"source": "if (ctx._source.containsKey('data')) {ctx._source.data.attributes = params.attributes}","lang": "painless","params": {"attributes": "%s"}}, "upsert": {}}`, base64Attr))
 		if len(nftUpdate.URIsToAdd) != 0 {

--- a/converters/tokenMetaData_test.go
+++ b/converters/tokenMetaData_test.go
@@ -46,7 +46,7 @@ func TestPrepareTokenMetaData(t *testing.T) {
 func TestPrepareNFTUpdateData(t *testing.T) {
 	t.Parallel()
 
-	buffSlice := data.NewBufferSlice()
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
 
 	nftUpdateData := []*data.NFTDataUpdate{
 		{
@@ -58,11 +58,11 @@ func TestPrepareNFTUpdateData(t *testing.T) {
 			URIsToAdd:  [][]byte{[]byte("uri1"), []byte("uri2")},
 		},
 	}
-	err := PrepareNFTUpdateData(buffSlice, nftUpdateData, false)
+	err := PrepareNFTUpdateData(buffSlice, nftUpdateData, false, "tokens")
 	require.Nil(t, err)
-	require.Equal(t, `{"update":{"_id":"MYTKN-abcd-01", "_type": "_doc"}}
+	require.Equal(t, `{"update":{ "_index":"tokens","_id":"MYTKN-abcd-01", "_type": "_doc"}}
 {"script": {"source": "if (ctx._source.containsKey('data')) {ctx._source.data.attributes = params.attributes}","lang": "painless","params": {"attributes": "YWFhYQ=="}}, "upsert": {}}
-{"update":{"_id":"TOKEN-1234-1a", "_type": "_doc"}}
+{"update":{ "_index":"tokens","_id":"TOKEN-1234-1a", "_type": "_doc"}}
 {"script": {"source": "if (ctx._source.containsKey('data')) { if (!ctx._source.data.containsKey('uris')) { ctx._source.data.uris = params.uris; } else {  ctx._source.data.uris.addAll(params.uris); }}","lang": "painless","params": {"uris": ["dXJpMQ==","dXJpMg=="]}},"upsert": {}}
 `, buffSlice.Buffers()[0].String())
 }

--- a/data/buffer.go
+++ b/data/buffer.go
@@ -13,10 +13,10 @@ type BufferSlice struct {
 }
 
 // NewBufferSlice will create a new buffer
-func NewBufferSlice() *BufferSlice {
+func NewBufferSlice(bulkSizeThreshold int) *BufferSlice {
 	return &BufferSlice{
 		buffSlice:         make([]*bytes.Buffer, 0),
-		bulkSizeThreshold: BulkSizeThreshold,
+		bulkSizeThreshold: bulkSizeThreshold,
 		idx:               0,
 	}
 }

--- a/data/buffer_test.go
+++ b/data/buffer_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestBufferSlice_PutDataShouldWork(t *testing.T) {
-	buffSlice := NewBufferSlice()
+	buffSlice := NewBufferSlice(BulkSizeThreshold)
 
 	meta := generateRandomBytes(100)
 	serializedData := generateRandomBytes(100)
@@ -25,7 +25,7 @@ func TestBufferSlice_PutDataShouldWork(t *testing.T) {
 }
 
 func TestBufferSlice_PutDataShouldWorkNilSerializedData(t *testing.T) {
-	buffSlice := NewBufferSlice()
+	buffSlice := NewBufferSlice(BulkSizeThreshold)
 
 	meta := []byte("my data")
 

--- a/data/interface.go
+++ b/data/interface.go
@@ -1,10 +1,8 @@
 package data
 
-import "bytes"
-
 // CountTags defines what a TagCount handler should be able to do
 type CountTags interface {
-	Serialize() ([]*bytes.Buffer, error)
+	Serialize(buffSlice *BufferSlice, index string) error
 	ParseTags(attributes []string)
 	GetTags() []string
 	Len() int

--- a/integrationtests/utils.go
+++ b/integrationtests/utils.go
@@ -6,6 +6,7 @@ import (
 
 	indexer "github.com/ElrondNetwork/elastic-indexer-go"
 	"github.com/ElrondNetwork/elastic-indexer-go/client"
+	"github.com/ElrondNetwork/elastic-indexer-go/client/logging"
 	"github.com/ElrondNetwork/elastic-indexer-go/data"
 	"github.com/ElrondNetwork/elastic-indexer-go/mock"
 	"github.com/ElrondNetwork/elastic-indexer-go/process"
@@ -24,6 +25,7 @@ func setLogLevelDebug() {
 func createESClient(url string) (process.DatabaseClientHandler, error) {
 	return client.NewElasticClient(elasticsearch.Config{
 		Addresses: []string{url},
+		Logger:    &logging.CustomLogger{},
 	})
 }
 

--- a/mock/dbAccountsHandlerStub.go
+++ b/mock/dbAccountsHandlerStub.go
@@ -1,15 +1,13 @@
 package mock
 
 import (
-	"bytes"
-
 	"github.com/ElrondNetwork/elastic-indexer-go/data"
 )
 
 // DBAccountsHandlerStub -
 type DBAccountsHandlerStub struct {
 	PrepareAccountsHistoryCalled   func(timestamp uint64, accounts map[string]*data.AccountInfo) map[string]*data.AccountBalanceHistory
-	SerializeAccountsHistoryCalled func(accounts map[string]*data.AccountBalanceHistory) ([]*bytes.Buffer, error)
+	SerializeAccountsHistoryCalled func(accounts map[string]*data.AccountBalanceHistory, buffSlice *data.BufferSlice, index string) error
 }
 
 // GetAccounts -
@@ -18,7 +16,7 @@ func (dba *DBAccountsHandlerStub) GetAccounts(_ data.AlteredAccountsHandler) ([]
 }
 
 // PrepareRegularAccountsMap -
-func (dba *DBAccountsHandlerStub) PrepareRegularAccountsMap(_ []*data.Account) map[string]*data.AccountInfo {
+func (dba *DBAccountsHandlerStub) PrepareRegularAccountsMap(_ uint64, _ []*data.Account) map[string]*data.AccountInfo {
 	return nil
 }
 
@@ -37,26 +35,26 @@ func (dba *DBAccountsHandlerStub) PrepareAccountsHistory(timestamp uint64, accou
 }
 
 // SerializeAccountsHistory -
-func (dba *DBAccountsHandlerStub) SerializeAccountsHistory(accounts map[string]*data.AccountBalanceHistory) ([]*bytes.Buffer, error) {
+func (dba *DBAccountsHandlerStub) SerializeAccountsHistory(accounts map[string]*data.AccountBalanceHistory, buffSlice *data.BufferSlice, index string) error {
 	if dba.SerializeAccountsHistoryCalled != nil {
-		return dba.SerializeAccountsHistoryCalled(accounts)
+		return dba.SerializeAccountsHistoryCalled(accounts, buffSlice, index)
 	}
-	return nil, nil
+	return nil
 }
 
 // SerializeAccounts -
-func (dba *DBAccountsHandlerStub) SerializeAccounts(_ map[string]*data.AccountInfo) ([]*bytes.Buffer, error) {
-	return nil, nil
+func (dba *DBAccountsHandlerStub) SerializeAccounts(_ map[string]*data.AccountInfo, _ *data.BufferSlice, _ string) error {
+	return nil
 }
 
 // SerializeAccountsESDT -
-func (dba *DBAccountsHandlerStub) SerializeAccountsESDT(_ map[string]*data.AccountInfo, _ []*data.NFTDataUpdate) ([]*bytes.Buffer, error) {
-	return nil, nil
+func (dba *DBAccountsHandlerStub) SerializeAccountsESDT(_ map[string]*data.AccountInfo, _ []*data.NFTDataUpdate, _ *data.BufferSlice, _ string) error {
+	return nil
 }
 
 // SerializeNFTCreateInfo -
-func (dba *DBAccountsHandlerStub) SerializeNFTCreateInfo(_ []*data.TokenInfo) ([]*bytes.Buffer, error) {
-	return nil, nil
+func (dba *DBAccountsHandlerStub) SerializeNFTCreateInfo(_ []*data.TokenInfo, _ *data.BufferSlice, _ string) error {
+	return nil
 }
 
 // PutTokenMedataDataInTokens -
@@ -64,6 +62,6 @@ func (dba *DBAccountsHandlerStub) PutTokenMedataDataInTokens(_ []*data.TokenInfo
 }
 
 // SerializeTypeForProvidedIDs -
-func (dba *DBAccountsHandlerStub) SerializeTypeForProvidedIDs(_ []string, _ string) ([]*bytes.Buffer, error) {
-	return nil, nil
+func (dba *DBAccountsHandlerStub) SerializeTypeForProvidedIDs(_ []string, _ string, _ *data.BufferSlice, _ string) error {
+	return nil
 }

--- a/mock/dbTransactionsHandlerStub.go
+++ b/mock/dbTransactionsHandlerStub.go
@@ -1,8 +1,6 @@
 package mock
 
 import (
-	"bytes"
-
 	"github.com/ElrondNetwork/elastic-indexer-go/data"
 	coreData "github.com/ElrondNetwork/elrond-go-core/data"
 	"github.com/ElrondNetwork/elrond-go-core/data/block"
@@ -12,12 +10,12 @@ import (
 // DBTransactionProcessorStub -
 type DBTransactionProcessorStub struct {
 	PrepareTransactionsForDatabaseCalled func(body *block.Body, header coreData.HeaderHandler, pool *indexer.Pool) *data.PreparedResults
-	SerializeReceiptsCalled              func(recs []*data.Receipt) ([]*bytes.Buffer, error)
-	SerializeScResultsCalled             func(scrs []*data.ScResult) ([]*bytes.Buffer, error)
+	SerializeReceiptsCalled              func(recs []*data.Receipt, buffSlice *data.BufferSlice, index string) error
+	SerializeScResultsCalled             func(scrs []*data.ScResult, buffSlice *data.BufferSlice, index string) error
 }
 
-func (tps *DBTransactionProcessorStub) SerializeTransactionWithRefund(_ map[string]*data.Transaction, _ map[string]*data.RefundData) ([]*bytes.Buffer, error) {
-	return nil, nil
+func (tps *DBTransactionProcessorStub) SerializeTransactionWithRefund(_ map[string]*data.Transaction, _ map[string]*data.RefundData, _ *data.BufferSlice, _ string) error {
+	return nil
 }
 
 // PrepareTransactionsForDatabase -
@@ -35,34 +33,34 @@ func (tps *DBTransactionProcessorStub) GetRewardsTxsHashesHexEncoded(_ coreData.
 }
 
 // SerializeReceipts -
-func (tps *DBTransactionProcessorStub) SerializeReceipts(recs []*data.Receipt) ([]*bytes.Buffer, error) {
+func (tps *DBTransactionProcessorStub) SerializeReceipts(recs []*data.Receipt, buffSlice *data.BufferSlice, index string) error {
 	if tps.SerializeReceiptsCalled != nil {
-		return tps.SerializeReceiptsCalled(recs)
+		return tps.SerializeReceiptsCalled(recs, buffSlice, index)
 	}
 
-	return nil, nil
+	return nil
 }
 
 // SerializeTransactions -
-func (tps *DBTransactionProcessorStub) SerializeTransactions(_ []*data.Transaction, _ map[string]string, _ uint32) ([]*bytes.Buffer, error) {
-	return nil, nil
+func (tps *DBTransactionProcessorStub) SerializeTransactions(_ []*data.Transaction, _ map[string]string, _ uint32, _ *data.BufferSlice, _ string) error {
+	return nil
 }
 
 // SerializeScResults -
-func (tps *DBTransactionProcessorStub) SerializeScResults(scrs []*data.ScResult) ([]*bytes.Buffer, error) {
+func (tps *DBTransactionProcessorStub) SerializeScResults(scrs []*data.ScResult, buffSlice *data.BufferSlice, index string) error {
 	if tps.SerializeScResultsCalled != nil {
-		return tps.SerializeScResultsCalled(scrs)
+		return tps.SerializeScResultsCalled(scrs, buffSlice, index)
 	}
 
-	return nil, nil
+	return nil
 }
 
 // SerializeDeploysData -
-func (tps *DBTransactionProcessorStub) SerializeDeploysData(_ []*data.ScDeployInfo) ([]*bytes.Buffer, error) {
-	return nil, nil
+func (tps *DBTransactionProcessorStub) SerializeDeploysData(_ []*data.ScDeployInfo, _ *data.BufferSlice, _ string) error {
+	return nil
 }
 
 // SerializeTokens -
-func (tps *DBTransactionProcessorStub) SerializeTokens(_ []*data.TokenInfo) ([]*bytes.Buffer, error) {
-	return nil, nil
+func (tps *DBTransactionProcessorStub) SerializeTokens(_ []*data.TokenInfo, _ *data.BufferSlice, _ string) error {
+	return nil
 }

--- a/process/accounts/accountsProcessor.go
+++ b/process/accounts/accountsProcessor.go
@@ -139,7 +139,7 @@ func (ap *accountsProcessor) getUserAccount(address string) (coreData.UserAccoun
 }
 
 // PrepareRegularAccountsMap will prepare a map of regular accounts
-func (ap *accountsProcessor) PrepareRegularAccountsMap(accounts []*data.Account) map[string]*data.AccountInfo {
+func (ap *accountsProcessor) PrepareRegularAccountsMap(timestamp uint64, accounts []*data.Account) map[string]*data.AccountInfo {
 	accountsMap := make(map[string]*data.AccountInfo)
 	for _, userAccount := range accounts {
 		address := ap.addressPubkeyConverter.Encode(userAccount.UserAccount.AddressBytes())
@@ -154,6 +154,7 @@ func (ap *accountsProcessor) PrepareRegularAccountsMap(accounts []*data.Account)
 			IsSmartContract:          core.IsSmartContractAddress(userAccount.UserAccount.AddressBytes()),
 			TotalBalanceWithStake:    balance.String(),
 			TotalBalanceWithStakeNum: balanceAsFloat,
+			Timestamp:                time.Duration(timestamp),
 		}
 
 		accountsMap[address] = acc

--- a/process/accounts/accountsProcessor_test.go
+++ b/process/accounts/accountsProcessor_test.go
@@ -90,7 +90,7 @@ func TestAccountsProcessor_PrepareRegularAccountsMapWithNil(t *testing.T) {
 
 	ap, _ := NewAccountsProcessor(&mock.MarshalizerMock{}, mock.NewPubkeyConverterMock(32), &mock.AccountsStub{}, balanceConverter)
 
-	accountsInfo := ap.PrepareRegularAccountsMap(nil)
+	accountsInfo := ap.PrepareRegularAccountsMap(0, nil)
 	require.Len(t, accountsInfo, 0)
 }
 
@@ -329,7 +329,7 @@ func TestAccountsProcessor_PrepareAccountsMapEGLD(t *testing.T) {
 	ap, _ := NewAccountsProcessor(&mock.MarshalizerMock{}, mock.NewPubkeyConverterMock(32), accountsStub, balanceConverter)
 	require.NotNil(t, ap)
 
-	res := ap.PrepareRegularAccountsMap([]*data.Account{egldAccount})
+	res := ap.PrepareRegularAccountsMap(123, []*data.Account{egldAccount})
 	require.Equal(t, map[string]*data.AccountInfo{
 		hex.EncodeToString([]byte(addr)): {
 			Address:                  hex.EncodeToString([]byte(addr)),
@@ -339,6 +339,7 @@ func TestAccountsProcessor_PrepareAccountsMapEGLD(t *testing.T) {
 			TotalBalanceWithStake:    "1000",
 			TotalBalanceWithStakeNum: balanceConverter.ComputeBalanceAsFloat(big.NewInt(1000)),
 			IsSmartContract:          true,
+			Timestamp:                time.Duration(123),
 		},
 	}, res)
 }

--- a/process/accounts/serialize.go
+++ b/process/accounts/serialize.go
@@ -1,7 +1,6 @@
 package accounts
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -10,85 +9,84 @@ import (
 )
 
 // SerializeNFTCreateInfo will serialize the provided nft create information in a way that Elastic Search expects a bulk request
-func (ap *accountsProcessor) SerializeNFTCreateInfo(tokensInfo []*data.TokenInfo) ([]*bytes.Buffer, error) {
-	buffSlice := data.NewBufferSlice()
+func (ap *accountsProcessor) SerializeNFTCreateInfo(tokensInfo []*data.TokenInfo, buffSlice *data.BufferSlice, index string) error {
 	for _, tokenData := range tokensInfo {
-		meta := []byte(fmt.Sprintf(`{ "index" : { "_id" : "%s" } }%s`, tokenData.Identifier, "\n"))
+		meta := []byte(fmt.Sprintf(`{ "index" : { "_index":"%s", "_id" : "%s" } }%s`, index, tokenData.Identifier, "\n"))
 		serializedData, errMarshal := json.Marshal(tokenData)
 		if errMarshal != nil {
-			return nil, errMarshal
+			return errMarshal
 		}
 
 		err := buffSlice.PutData(meta, serializedData)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return buffSlice.Buffers(), nil
+	return nil
 }
 
 // SerializeAccounts will serialize the provided accounts in a way that Elasticsearch expects a bulk request
-func (ap *accountsProcessor) SerializeAccounts(accounts map[string]*data.AccountInfo) ([]*bytes.Buffer, error) {
-	buffSlice := data.NewBufferSlice()
+func (ap *accountsProcessor) SerializeAccounts(accounts map[string]*data.AccountInfo, buffSlice *data.BufferSlice, index string) error {
 	for _, acc := range accounts {
-		meta, serializedData, err := prepareSerializedAccount(acc, false)
+		meta, serializedData, err := prepareSerializedAccount(acc, false, index)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		err = buffSlice.PutData(meta, serializedData)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return buffSlice.Buffers(), nil
+	return nil
 }
 
 // SerializeAccountsESDT will serialize the provided accounts and nfts updates in a way that Elasticsearch expects a bulk request
 func (ap *accountsProcessor) SerializeAccountsESDT(
 	accounts map[string]*data.AccountInfo,
 	updateNFTData []*data.NFTDataUpdate,
-) ([]*bytes.Buffer, error) {
-	buffSlice := data.NewBufferSlice()
+	buffSlice *data.BufferSlice,
+	index string,
+) error {
 	for _, acc := range accounts {
-		meta, serializedData, err := prepareSerializedAccount(acc, true)
+		meta, serializedData, err := prepareSerializedAccount(acc, true, index)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		err = buffSlice.PutData(meta, serializedData)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	err := converters.PrepareNFTUpdateData(buffSlice, updateNFTData, true)
+	err := converters.PrepareNFTUpdateData(buffSlice, updateNFTData, true, index)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return buffSlice.Buffers(), nil
+	return nil
 }
 
-func prepareSerializedAccount(acc *data.AccountInfo, isESDT bool) ([]byte, []byte, error) {
+func prepareSerializedAccount(acc *data.AccountInfo, isESDT bool, index string) ([]byte, []byte, error) {
 	if (acc.Balance == "0" || acc.Balance == "") && isESDT {
-		meta := prepareDeleteAccountInfo(acc, isESDT)
+		meta := prepareDeleteAccountInfo(acc, isESDT, index)
 		return meta, nil, nil
 	}
 
-	return prepareSerializedAccountInfo(acc, isESDT)
+	return prepareSerializedAccountInfo(acc, isESDT, index)
 }
 
-func prepareDeleteAccountInfo(acct *data.AccountInfo, isESDT bool) []byte {
+func prepareDeleteAccountInfo(acct *data.AccountInfo, isESDT bool, index string) []byte {
 	id := acct.Address
 	if isESDT {
 		hexEncodedNonce := converters.EncodeNonceToHex(acct.TokenNonce)
 		id += fmt.Sprintf("-%s-%s", acct.TokenName, hexEncodedNonce)
 	}
 
-	meta := []byte(fmt.Sprintf(`{ "delete" : { "_id" : "%s" } }%s`, id, "\n"))
+	meta := []byte(fmt.Sprintf(`{ "delete" : {"_index":"%s", "_id" : "%s" } }%s`, index, id, "\n"))
 
 	return meta
 }
@@ -96,6 +94,7 @@ func prepareDeleteAccountInfo(acct *data.AccountInfo, isESDT bool) []byte {
 func prepareSerializedAccountInfo(
 	account *data.AccountInfo,
 	isESDTAccount bool,
+	index string,
 ) ([]byte, []byte, error) {
 	id := account.Address
 	if isESDTAccount {
@@ -103,7 +102,7 @@ func prepareSerializedAccountInfo(
 		id += fmt.Sprintf("-%s-%s", account.TokenName, hexEncodedNonce)
 	}
 
-	meta := []byte(fmt.Sprintf(`{ "index" : { "_id" : "%s" } }%s`, id, "\n"))
+	meta := []byte(fmt.Sprintf(`{ "index" : { "_index":"%s", "_id" : "%s" } }%s`, index, id, "\n"))
 	serializedData, err := json.Marshal(account)
 	if err != nil {
 		return nil, nil, err
@@ -113,27 +112,31 @@ func prepareSerializedAccountInfo(
 }
 
 // SerializeAccountsHistory will serialize accounts history in a way that Elastic Search expects a bulk request
-func (ap *accountsProcessor) SerializeAccountsHistory(accounts map[string]*data.AccountBalanceHistory) ([]*bytes.Buffer, error) {
+func (ap *accountsProcessor) SerializeAccountsHistory(
+	accounts map[string]*data.AccountBalanceHistory,
+	buffSlice *data.BufferSlice,
+	index string,
+) error {
 	var err error
 
-	buffSlice := data.NewBufferSlice()
 	for _, acc := range accounts {
-		meta, serializedData, errPrepareAcc := prepareSerializedAccountBalanceHistory(acc)
+		meta, serializedData, errPrepareAcc := prepareSerializedAccountBalanceHistory(acc, index)
 		if errPrepareAcc != nil {
-			return nil, err
+			return err
 		}
 
 		err = buffSlice.PutData(meta, serializedData)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return buffSlice.Buffers(), nil
+	return nil
 }
 
 func prepareSerializedAccountBalanceHistory(
 	account *data.AccountBalanceHistory,
+	index string,
 ) ([]byte, []byte, error) {
 	id := account.Address
 
@@ -144,7 +147,7 @@ func prepareSerializedAccountBalanceHistory(
 	}
 
 	id += fmt.Sprintf("-%d", account.Timestamp)
-	meta := []byte(fmt.Sprintf(`{ "index" : { "_id" : "%s" } }%s`, id, "\n"))
+	meta := []byte(fmt.Sprintf(`{ "index" : { "_index":"%s", "_id" : "%s" } }%s`, index, id, "\n"))
 
 	serializedData, err := json.Marshal(account)
 	if err != nil {
@@ -155,11 +158,14 @@ func prepareSerializedAccountBalanceHistory(
 }
 
 // SerializeTypeForProvidedIDs will serialize the type for the provided ids
-func (ap *accountsProcessor) SerializeTypeForProvidedIDs(ids []string, tokenType string) ([]*bytes.Buffer, error) {
-	buffSlice := data.NewBufferSlice()
-
+func (ap *accountsProcessor) SerializeTypeForProvidedIDs(
+	ids []string,
+	tokenType string,
+	buffSlice *data.BufferSlice,
+	index string,
+) error {
 	for _, id := range ids {
-		meta := []byte(fmt.Sprintf(`{ "update" : { "_id" : "%s", "_type" : "_doc" } }%s`, id, "\n"))
+		meta := []byte(fmt.Sprintf(`{ "update" : {"_index":"%s", "_id" : "%s", "_type" : "_doc" } }%s`, index, id, "\n"))
 
 		serializedDataStr := fmt.Sprintf(`{"scripted_upsert": true, "script": {`+
 			`"source": "if ( ctx.op == 'create' )  { ctx.op = 'noop' } else  { ctx._source.type = params.type }",`+
@@ -170,9 +176,9 @@ func (ap *accountsProcessor) SerializeTypeForProvidedIDs(ids []string, tokenType
 
 		err := buffSlice.PutData(meta, []byte(serializedDataStr))
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return buffSlice.Buffers(), nil
+	return nil
 }

--- a/process/accounts/serialize_test.go
+++ b/process/accounts/serialize_test.go
@@ -23,14 +23,15 @@ func TestSerializeNFTCreateInfo(t *testing.T) {
 		},
 	}
 
-	res, err := (&accountsProcessor{}).SerializeNFTCreateInfo(nftsCreateInfo)
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := (&accountsProcessor{}).SerializeNFTCreateInfo(nftsCreateInfo, buffSlice, "tokens")
 	require.NoError(t, err)
-	require.Equal(t, 1, len(res))
+	require.Equal(t, 1, len(buffSlice.Buffers()))
 
-	expectedRes := `{ "index" : { "_id" : "my-token-001-0f" } }
+	expectedRes := `{ "index" : { "_index":"tokens", "_id" : "my-token-001-0f" } }
 {"identifier":"my-token-001-0f","token":"my-token-0001","type":"NonFungibleESDT","data":{"creator":"010102","nonEmptyURIs":false,"whiteListedStorage":false}}
 `
-	require.Equal(t, expectedRes, res[0].String())
+	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
 }
 
 func TestSerializeAccounts(t *testing.T) {
@@ -49,14 +50,15 @@ func TestSerializeAccounts(t *testing.T) {
 		},
 	}
 
-	res, err := (&accountsProcessor{}).SerializeAccounts(accs)
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := (&accountsProcessor{}).SerializeAccounts(accs, buffSlice, "accounts")
 	require.NoError(t, err)
-	require.Equal(t, 1, len(res))
+	require.Equal(t, 1, len(buffSlice.Buffers()))
 
-	expectedRes := `{ "index" : { "_id" : "addr1" } }
+	expectedRes := `{ "index" : { "_index":"accounts", "_id" : "addr1" } }
 {"address":"addr1","nonce":1,"balance":"50","balanceNum":0.1,"totalBalanceWithStake":"50","totalBalanceWithStakeNum":0.1}
 `
-	require.Equal(t, expectedRes, res[0].String())
+	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
 }
 
 func TestSerializeAccountsESDTNonceZero(t *testing.T) {
@@ -75,14 +77,15 @@ func TestSerializeAccountsESDTNonceZero(t *testing.T) {
 		},
 	}
 
-	res, err := (&accountsProcessor{}).SerializeAccountsESDT(accs, nil)
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := (&accountsProcessor{}).SerializeAccountsESDT(accs, nil, buffSlice, "accountsesdt")
 	require.NoError(t, err)
-	require.Equal(t, 1, len(res))
+	require.Equal(t, 1, len(buffSlice.Buffers()))
 
-	expectedRes := `{ "index" : { "_id" : "addr1-token-abcd-00" } }
+	expectedRes := `{ "index" : { "_index":"accountsesdt", "_id" : "addr1-token-abcd-00" } }
 {"address":"addr1","nonce":1,"balance":"10000000000000","balanceNum":1,"token":"token-abcd","properties":"000","timestamp":123}
 `
-	require.Equal(t, expectedRes, res[0].String())
+	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
 }
 
 func TestSerializeAccountsESDT(t *testing.T) {
@@ -100,14 +103,15 @@ func TestSerializeAccountsESDT(t *testing.T) {
 		},
 	}
 
-	res, err := (&accountsProcessor{}).SerializeAccountsESDT(accs, nil)
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := (&accountsProcessor{}).SerializeAccountsESDT(accs, nil, buffSlice, "accountsesdt")
 	require.NoError(t, err)
-	require.Equal(t, 1, len(res))
+	require.Equal(t, 1, len(buffSlice.Buffers()))
 
-	expectedRes := `{ "index" : { "_id" : "addr1-token-0001-05" } }
+	expectedRes := `{ "index" : { "_index":"accountsesdt", "_id" : "addr1-token-0001-05" } }
 {"address":"addr1","nonce":1,"balance":"10000000000000","balanceNum":1,"token":"token-0001","tokenNonce":5,"properties":"000"}
 `
-	require.Equal(t, expectedRes, res[0].String())
+	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
 }
 
 func TestSerializeAccountsNFTWithMedaData(t *testing.T) {
@@ -139,14 +143,15 @@ func TestSerializeAccountsNFTWithMedaData(t *testing.T) {
 		},
 	}
 
-	res, err := (&accountsProcessor{}).SerializeAccountsESDT(accs, nil)
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := (&accountsProcessor{}).SerializeAccountsESDT(accs, nil, buffSlice, "accountsesdt")
 	require.NoError(t, err)
-	require.Equal(t, 1, len(res))
+	require.Equal(t, 1, len(buffSlice.Buffers()))
 
-	expectedRes := `{ "index" : { "_id" : "addr1-token-0001-16" } }
+	expectedRes := `{ "index" : { "_index":"accountsesdt", "_id" : "addr1-token-0001-16" } }
 {"address":"addr1","nonce":1,"balance":"10000000000000","balanceNum":1,"token":"token-0001","identifier":"token-0001-5","tokenNonce":22,"properties":"000","data":{"name":"nft","creator":"010101","royalties":1,"hash":"aGFzaA==","uris":["dXJp"],"tags":["test","free","fun"],"attributes":"dGFnczp0ZXN0LGZyZWUsZnVuO2Rlc2NyaXB0aW9uOlRoaXMgaXMgYSB0ZXN0IGRlc2NyaXB0aW9uIGZvciBhbiBhd2Vzb21lIG5mdA==","metadata":"metadata-test","nonEmptyURIs":true,"whiteListedStorage":false}}
 `
-	require.Equal(t, expectedRes, res[0].String())
+	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
 }
 
 func TestSerializeAccountsESDTDelete(t *testing.T) {
@@ -163,13 +168,14 @@ func TestSerializeAccountsESDTDelete(t *testing.T) {
 		},
 	}
 
-	res, err := (&accountsProcessor{}).SerializeAccountsESDT(accs, nil)
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := (&accountsProcessor{}).SerializeAccountsESDT(accs, nil, buffSlice, "accountsesdt")
 	require.NoError(t, err)
-	require.Equal(t, 1, len(res))
+	require.Equal(t, 1, len(buffSlice.Buffers()))
 
-	expectedRes := `{ "delete" : { "_id" : "addr1-token-0001-00" } }
+	expectedRes := `{ "delete" : {"_index":"accountsesdt", "_id" : "addr1-token-0001-00" } }
 `
-	require.Equal(t, expectedRes, res[0].String())
+	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
 }
 
 func TestSerializeAccountsHistory(t *testing.T) {
@@ -186,12 +192,13 @@ func TestSerializeAccountsHistory(t *testing.T) {
 		},
 	}
 
-	res, err := (&accountsProcessor{}).SerializeAccountsHistory(accsh)
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := (&accountsProcessor{}).SerializeAccountsHistory(accsh, buffSlice, "accountshistory")
 	require.NoError(t, err)
-	require.Equal(t, 1, len(res))
+	require.Equal(t, 1, len(buffSlice.Buffers()))
 
-	expectedRes := `{ "index" : { "_id" : "account1-token-0001-00-10" } }
+	expectedRes := `{ "index" : { "_index":"accountshistory", "_id" : "account1-token-0001-00-10" } }
 {"address":"account1","timestamp":10,"balance":"123","token":"token-0001","isSender":true,"isSmartContract":true}
 `
-	require.Equal(t, expectedRes, res[0].String())
+	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
 }

--- a/process/block/serialize_test.go
+++ b/process/block/serialize_test.go
@@ -18,7 +18,7 @@ func TestBlockProcessor_SerializeBlockNilElasticBlockErrors(t *testing.T) {
 
 	bp, _ := NewBlockProcessor(&mock.HasherMock{}, &mock.MarshalizerMock{})
 
-	_, err := bp.SerializeBlock(nil)
+	err := bp.SerializeBlock(nil, nil, "")
 	require.True(t, errors.Is(err, indexer.ErrNilElasticBlock))
 }
 
@@ -27,9 +27,12 @@ func TestBlockProcessor_SerializeBlock(t *testing.T) {
 
 	bp, _ := NewBlockProcessor(&mock.HasherMock{}, &mock.MarshalizerMock{})
 
-	buff, err := bp.SerializeBlock(&data.Block{Nonce: 1})
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := bp.SerializeBlock(&data.Block{Nonce: 1}, buffSlice, "blocks")
 	require.Nil(t, err)
-	require.Equal(t, `{"nonce":1,"round":0,"epoch":0,"miniBlocksHashes":null,"notarizedBlocksHashes":null,"proposer":0,"validators":null,"pubKeyBitmap":"","size":0,"sizeTxs":0,"timestamp":0,"stateRootHash":"","prevHash":"","shardId":0,"txCount":0,"notarizedTxsCount":0,"accumulatedFees":"","developerFees":"","epochStartBlock":false,"searchOrder":0,"gasProvided":0,"gasRefunded":0,"gasPenalized":0,"maxGasLimit":0}`, buff.String())
+	require.Equal(t, `{ "index" : { "_index":"blocks", "_id" : "" } }
+{"nonce":1,"round":0,"epoch":0,"miniBlocksHashes":null,"notarizedBlocksHashes":null,"proposer":0,"validators":null,"pubKeyBitmap":"","size":0,"sizeTxs":0,"timestamp":0,"stateRootHash":"","prevHash":"","shardId":0,"txCount":0,"notarizedTxsCount":0,"accumulatedFees":"","developerFees":"","epochStartBlock":false,"searchOrder":0,"gasProvided":0,"gasRefunded":0,"gasPenalized":0,"maxGasLimit":0}
+`, buffSlice.Buffers()[0].String())
 }
 
 func TestBlockProcessor_SerializeEpochInfoDataErrors(t *testing.T) {
@@ -37,10 +40,10 @@ func TestBlockProcessor_SerializeEpochInfoDataErrors(t *testing.T) {
 
 	bp, _ := NewBlockProcessor(&mock.HasherMock{}, &mock.MarshalizerMock{})
 
-	_, err := bp.SerializeEpochInfoData(nil)
+	err := bp.SerializeEpochInfoData(nil, nil, "")
 	require.Equal(t, indexer.ErrNilHeaderHandler, err)
 
-	_, err = bp.SerializeEpochInfoData(&dataBlock.Header{})
+	err = bp.SerializeEpochInfoData(&dataBlock.Header{}, nil, "")
 	require.True(t, errors.Is(err, indexer.ErrHeaderTypeAssertion))
 }
 
@@ -49,12 +52,15 @@ func TestBlockProcessor_SerializeEpochInfoData(t *testing.T) {
 
 	bp, _ := NewBlockProcessor(&mock.HasherMock{}, &mock.MarshalizerMock{})
 
-	buff, err := bp.SerializeEpochInfoData(&dataBlock.MetaBlock{
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := bp.SerializeEpochInfoData(&dataBlock.MetaBlock{
 		AccumulatedFeesInEpoch: big.NewInt(1),
 		DevFeesInEpoch:         big.NewInt(2),
-	})
+	}, buffSlice, "epochinfo")
 	require.Nil(t, err)
-	require.Equal(t, `{"accumulatedFees":"1","developerFees":"2"}`, buff.String())
+	require.Equal(t, `{ "index" : { "_index":"epochinfo", "_id" : "0" } }
+{"accumulatedFees":"1","developerFees":"2"}
+`, buffSlice.Buffers()[0].String())
 }
 
 func TestBlockProcessor_SerializeBlockEpochStartMeta(t *testing.T) {
@@ -62,7 +68,8 @@ func TestBlockProcessor_SerializeBlockEpochStartMeta(t *testing.T) {
 
 	bp, _ := NewBlockProcessor(&mock.HasherMock{}, &mock.MarshalizerMock{})
 
-	buff, err := bp.SerializeBlock(&data.Block{
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := bp.SerializeBlock(&data.Block{
 		Nonce:                 1,
 		Round:                 2,
 		Epoch:                 3,
@@ -93,7 +100,9 @@ func TestBlockProcessor_SerializeBlockEpochStartMeta(t *testing.T) {
 			PrevEpochStartRound:              222,
 			PrevEpochStartHash:               "7072657645706f6368",
 		},
-	})
+	}, buffSlice, "blocks")
 	require.Nil(t, err)
-	require.Equal(t, `{"nonce":1,"round":2,"epoch":3,"miniBlocksHashes":["mb1Hash","mbHash2"],"notarizedBlocksHashes":["notarized1"],"proposer":5,"validators":[0,1,2,3,4,5],"pubKeyBitmap":"00000110","size":345,"sizeTxs":0,"timestamp":123456,"stateRootHash":"stateHash","prevHash":"prevHash","shardId":4294967295,"txCount":100,"notarizedTxsCount":120,"accumulatedFees":"1000","developerFees":"50","epochStartBlock":true,"searchOrder":1010,"epochStartInfo":{"totalSupply":"100","totalToDistribute":"55","totalNewlyMinted":"20","rewardsPerBlock":"15","rewardsForProtocolSustainability":"2","nodePrice":"10","prevEpochStartRound":222,"prevEpochStartHash":"7072657645706f6368"},"gasProvided":0,"gasRefunded":0,"gasPenalized":0,"maxGasLimit":0}`, buff.String())
+	require.Equal(t, `{ "index" : { "_index":"blocks", "_id" : "11cb2a3a28522a11ae646a93aa4d50f87194cead7d6edeb333d502349407b61d" } }
+{"nonce":1,"round":2,"epoch":3,"miniBlocksHashes":["mb1Hash","mbHash2"],"notarizedBlocksHashes":["notarized1"],"proposer":5,"validators":[0,1,2,3,4,5],"pubKeyBitmap":"00000110","size":345,"sizeTxs":0,"timestamp":123456,"stateRootHash":"stateHash","prevHash":"prevHash","shardId":4294967295,"txCount":100,"notarizedTxsCount":120,"accumulatedFees":"1000","developerFees":"50","epochStartBlock":true,"searchOrder":1010,"epochStartInfo":{"totalSupply":"100","totalToDistribute":"55","totalNewlyMinted":"20","rewardsPerBlock":"15","rewardsForProtocolSustainability":"2","nodePrice":"10","prevEpochStartRound":222,"prevEpochStartHash":"7072657645706f6368"},"gasProvided":0,"gasRefunded":0,"gasPenalized":0,"maxGasLimit":0}
+`, buffSlice.Buffers()[0].String())
 }

--- a/process/elasticProcessor.go
+++ b/process/elasticProcessor.go
@@ -256,43 +256,27 @@ func (ei *elasticProcessor) SaveHeader(
 		return err
 	}
 
-	buff, err := ei.blockProc.SerializeBlock(elasticBlock)
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err = ei.blockProc.SerializeBlock(elasticBlock, buffSlice, elasticIndexer.BlockIndex)
 	if err != nil {
 		return err
 	}
 
-	req := &esapi.IndexRequest{
-		Index:      elasticIndexer.BlockIndex,
-		DocumentID: elasticBlock.Hash,
-		Body:       bytes.NewReader(buff.Bytes()),
-	}
-
-	err = ei.elasticClient.DoRequest(req)
+	err = ei.indexEpochInfoData(header, buffSlice)
 	if err != nil {
 		return err
 	}
 
-	return ei.indexEpochInfoData(header)
+	return ei.doBulkRequests("", buffSlice.Buffers())
 }
 
-func (ei *elasticProcessor) indexEpochInfoData(header coreData.HeaderHandler) error {
+func (ei *elasticProcessor) indexEpochInfoData(header coreData.HeaderHandler, buffSlice *data.BufferSlice) error {
 	if !ei.isIndexEnabled(elasticIndexer.EpochInfoIndex) ||
 		ei.selfShardID != core.MetachainShardId {
 		return nil
 	}
 
-	buff, err := ei.blockProc.SerializeEpochInfoData(header)
-	if err != nil {
-		return err
-	}
-
-	req := &esapi.IndexRequest{
-		Index:      elasticIndexer.EpochInfoIndex,
-		DocumentID: fmt.Sprintf("%d", header.GetEpoch()),
-		Body:       bytes.NewReader(buff.Bytes()),
-	}
-
-	return ei.elasticClient.DoRequest(req)
+	return ei.blockProc.SerializeEpochInfoData(header, buffSlice, elasticIndexer.EpochInfoIndex)
 }
 
 // RemoveHeader will remove a block from elasticsearch server
@@ -341,8 +325,10 @@ func (ei *elasticProcessor) SaveMiniblocks(header coreData.HeaderHandler, body *
 		log.Warn("elasticProcessor.SaveMiniblocks cannot get indexed miniblocks", "error", err)
 	}
 
-	buff := ei.miniblocksProc.SerializeBulkMiniBlocks(mbs, miniblocksInDBMap)
-	return ei.elasticClient.DoBulkRequest(buff, elasticIndexer.MiniblocksIndex)
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	ei.miniblocksProc.SerializeBulkMiniBlocks(mbs, miniblocksInDBMap, buffSlice, elasticIndexer.MiniblocksIndex)
+
+	return ei.doBulkRequests("", buffSlice.Buffers())
 }
 
 func (ei *elasticProcessor) miniblocksInDBMap(mbs []*data.Miniblock) (map[string]bool, error) {
@@ -365,97 +351,97 @@ func (ei *elasticProcessor) SaveTransactions(
 	preparedResults := ei.transactionsProc.PrepareTransactionsForDatabase(body, header, pool)
 	logsData := ei.logsAndEventsProc.ExtractDataFromLogs(pool.Logs, preparedResults, headerTimestamp)
 
-	err := ei.indexTransactions(preparedResults.Transactions, preparedResults.TxHashStatus, header)
+	buffers := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := ei.indexTransactions(preparedResults.Transactions, preparedResults.TxHashStatus, header, buffers)
 	if err != nil {
 		return err
 	}
 
-	err = ei.indexTransactionsWithRefund(preparedResults.TxHashRefund)
+	err = ei.indexTransactionsWithRefund(preparedResults.TxHashRefund, buffers)
 	if err != nil {
 		return err
 	}
 
-	err = ei.prepareAndIndexTagsCount(logsData.TagsCount)
+	err = ei.prepareAndIndexTagsCount(logsData.TagsCount, buffers)
 	if err != nil {
 		return err
 	}
 
-	err = ei.indexNFTCreateInfo(logsData.Tokens)
+	err = ei.indexNFTCreateInfo(logsData.Tokens, buffers)
 	if err != nil {
 		return err
 	}
 
-	err = ei.prepareAndIndexLogs(pool.Logs, headerTimestamp)
+	err = ei.prepareAndIndexLogs(pool.Logs, headerTimestamp, buffers)
 	if err != nil {
 		return err
 	}
 
-	err = ei.indexScResults(preparedResults.ScResults)
+	err = ei.indexScResults(preparedResults.ScResults, buffers)
 	if err != nil {
 		return err
 	}
 
-	err = ei.indexReceipts(preparedResults.Receipts)
+	err = ei.indexReceipts(preparedResults.Receipts, buffers)
 	if err != nil {
 		return err
 	}
 
-	err = ei.indexAlteredAccounts(headerTimestamp, preparedResults.AlteredAccts, logsData.NFTsDataUpdates)
+	err = ei.indexAlteredAccounts(headerTimestamp, preparedResults.AlteredAccts, logsData.NFTsDataUpdates, buffers)
 	if err != nil {
 		return err
 	}
 
-	err = ei.indexTokens(logsData.TokensInfo, logsData.NFTsDataUpdates)
+	err = ei.indexTokens(logsData.TokensInfo, logsData.NFTsDataUpdates, buffers)
 	if err != nil {
 		return err
 	}
 
-	err = ei.prepareAndIndexDelegators(logsData.Delegators)
+	err = ei.prepareAndIndexDelegators(logsData.Delegators, buffers)
 	if err != nil {
 		return err
 	}
 
-	err = ei.prepareAndIndexOperations(preparedResults.Transactions, preparedResults.TxHashStatus, header, preparedResults.ScResults)
+	err = ei.prepareAndIndexOperations(preparedResults.Transactions, preparedResults.TxHashStatus, header, preparedResults.ScResults, buffers)
 	if err != nil {
 		return err
 	}
 
-	err = ei.indexNFTBurnInfo(logsData.TokensSupply)
+	err = ei.indexNFTBurnInfo(logsData.TokensSupply, buffers)
 	if err != nil {
 		return err
 	}
 
-	err = ei.prepareAndIndexRolesData(logsData.RolesData)
+	err = ei.prepareAndIndexRolesData(logsData.RolesData, buffers)
 	if err != nil {
 		return err
 	}
 
-	return ei.indexScDeploys(logsData.ScDeploys)
+	err = ei.indexScDeploys(logsData.ScDeploys, buffers)
+	if err != nil {
+		return err
+	}
+
+	return ei.doBulkRequests("", buffers.Buffers())
 }
 
-func (ei *elasticProcessor) prepareAndIndexRolesData(rolesData data.RolesData) error {
-	buffSlice, err := ei.logsAndEventsProc.SerializeRolesData(rolesData)
-	if err != nil {
-		return err
+func (ei *elasticProcessor) prepareAndIndexRolesData(rolesData data.RolesData, buffSlice *data.BufferSlice) error {
+	if !ei.isIndexEnabled(elasticIndexer.TokensIndex) {
+		return nil
 	}
 
-	return ei.doBulkRequests(elasticIndexer.TokensIndex, buffSlice)
+	return ei.logsAndEventsProc.SerializeRolesData(rolesData, buffSlice, elasticIndexer.TokensIndex)
 }
 
-func (ei *elasticProcessor) prepareAndIndexDelegators(delegators map[string]*data.Delegator) error {
+func (ei *elasticProcessor) prepareAndIndexDelegators(delegators map[string]*data.Delegator, buffSlice *data.BufferSlice) error {
 	if !ei.isIndexEnabled(elasticIndexer.DelegatorsIndex) {
 		return nil
 	}
 
-	buffSlice, err := ei.logsAndEventsProc.SerializeDelegators(delegators)
-	if err != nil {
-		return err
-	}
-
-	return ei.doBulkRequests(elasticIndexer.DelegatorsIndex, buffSlice)
+	return ei.logsAndEventsProc.SerializeDelegators(delegators, buffSlice, elasticIndexer.DelegatorsIndex)
 }
 
-func (ei *elasticProcessor) indexTransactionsWithRefund(txsHashRefund map[string]*data.RefundData) error {
+func (ei *elasticProcessor) indexTransactionsWithRefund(txsHashRefund map[string]*data.RefundData, buffSlice *data.BufferSlice) error {
 	if len(txsHashRefund) == 0 {
 		return nil
 	}
@@ -480,77 +466,54 @@ func (ei *elasticProcessor) indexTransactionsWithRefund(txsHashRefund map[string
 		txsFromDB[txRes.ID] = &txRes.Source
 	}
 
-	buffSlice, err := ei.transactionsProc.SerializeTransactionWithRefund(txsFromDB, txsHashRefund)
-	if err != nil {
-		return err
-	}
-
-	return ei.doBulkRequests(elasticIndexer.TransactionsIndex, buffSlice)
+	return ei.transactionsProc.SerializeTransactionWithRefund(txsFromDB, txsHashRefund, buffSlice, elasticIndexer.TransactionsIndex)
 }
 
-func (ei *elasticProcessor) prepareAndIndexLogs(logsAndEvents []*coreData.LogData, timestamp uint64) error {
+func (ei *elasticProcessor) prepareAndIndexLogs(logsAndEvents []*coreData.LogData, timestamp uint64, buffSlice *data.BufferSlice) error {
 	if !ei.isIndexEnabled(elasticIndexer.LogsIndex) {
 		return nil
 	}
 
 	logsDB := ei.logsAndEventsProc.PrepareLogsForDB(logsAndEvents, timestamp)
-	buffSlice, err := ei.logsAndEventsProc.SerializeLogs(logsDB)
-	if err != nil {
-		return err
-	}
 
-	return ei.doBulkRequests(elasticIndexer.LogsIndex, buffSlice)
+	return ei.logsAndEventsProc.SerializeLogs(logsDB, buffSlice, elasticIndexer.LogsIndex)
 }
 
-func (ei *elasticProcessor) indexScDeploys(deployData map[string]*data.ScDeployInfo) error {
+func (ei *elasticProcessor) indexScDeploys(deployData map[string]*data.ScDeployInfo, buffSlice *data.BufferSlice) error {
 	if !ei.isIndexEnabled(elasticIndexer.SCDeploysIndex) {
 		return nil
 	}
 
-	buffSlice, err := ei.logsAndEventsProc.SerializeSCDeploys(deployData)
-	if err != nil {
-		return err
-	}
-
-	return ei.doBulkRequests(elasticIndexer.SCDeploysIndex, buffSlice)
+	return ei.logsAndEventsProc.SerializeSCDeploys(deployData, buffSlice, elasticIndexer.SCDeploysIndex)
 }
 
-func (ei *elasticProcessor) indexTransactions(txs []*data.Transaction, txHashStatus map[string]string, header coreData.HeaderHandler) error {
+func (ei *elasticProcessor) indexTransactions(txs []*data.Transaction, txHashStatus map[string]string, header coreData.HeaderHandler, bytesBuff *data.BufferSlice) error {
 	if !ei.isIndexEnabled(elasticIndexer.TransactionsIndex) {
 		return nil
 	}
 
-	buffSlice, err := ei.transactionsProc.SerializeTransactions(txs, txHashStatus, header.GetShardID())
-	if err != nil {
-		return err
-	}
-
-	return ei.doBulkRequests(elasticIndexer.TransactionsIndex, buffSlice)
+	return ei.transactionsProc.SerializeTransactions(txs, txHashStatus, header.GetShardID(), bytesBuff, elasticIndexer.TransactionsIndex)
 }
 
-func (ei *elasticProcessor) prepareAndIndexOperations(txs []*data.Transaction, txHashStatus map[string]string, header coreData.HeaderHandler, scrs []*data.ScResult) error {
+func (ei *elasticProcessor) prepareAndIndexOperations(
+	txs []*data.Transaction,
+	txHashStatus map[string]string,
+	header coreData.HeaderHandler,
+	scrs []*data.ScResult,
+	buffSlice *data.BufferSlice,
+) error {
 	if !ei.isIndexEnabled(elasticIndexer.OperationsIndex) {
 		return nil
 	}
 
 	processedTxs, processedSCRs := ei.operationsProc.ProcessTransactionsAndSCRs(txs, scrs)
 
-	buffSlice, err := ei.transactionsProc.SerializeTransactions(processedTxs, txHashStatus, header.GetShardID())
+	err := ei.transactionsProc.SerializeTransactions(processedTxs, txHashStatus, header.GetShardID(), buffSlice, elasticIndexer.OperationsIndex)
 	if err != nil {
 		return err
 	}
 
-	err = ei.doBulkRequests(elasticIndexer.OperationsIndex, buffSlice)
-	if err != nil {
-		return err
-	}
-
-	buffSliceSCRs, err := ei.operationsProc.SerializeSCRs(processedSCRs)
-	if err != nil {
-		return err
-	}
-
-	return ei.doBulkRequests(elasticIndexer.OperationsIndex, buffSliceSCRs)
+	return ei.operationsProc.SerializeSCRs(processedSCRs, buffSlice, elasticIndexer.OperationsIndex)
 }
 
 // SaveValidatorsRating will save validators rating
@@ -603,21 +566,23 @@ func (ei *elasticProcessor) indexAlteredAccounts(
 	timestamp uint64,
 	alteredAccounts data.AlteredAccountsHandler,
 	updatesNFTsData []*data.NFTDataUpdate,
+	buffSlice *data.BufferSlice,
 ) error {
 	regularAccountsToIndex, accountsToIndexESDT := ei.accountsProc.GetAccounts(alteredAccounts)
 
-	err := ei.SaveAccounts(timestamp, regularAccountsToIndex)
+	err := ei.saveAccounts(timestamp, regularAccountsToIndex, buffSlice)
 	if err != nil {
 		return err
 	}
 
-	return ei.saveAccountsESDT(timestamp, accountsToIndexESDT, updatesNFTsData)
+	return ei.saveAccountsESDT(timestamp, accountsToIndexESDT, updatesNFTsData, buffSlice)
 }
 
 func (ei *elasticProcessor) saveAccountsESDT(
 	timestamp uint64,
 	wrappedAccounts []*data.AccountESDT,
 	updatesNFTsData []*data.NFTDataUpdate,
+	buffSlice *data.BufferSlice,
 ) error {
 	accountsESDTMap, tokensData := ei.accountsProc.PrepareAccountsMapESDT(timestamp, wrappedAccounts)
 	err := ei.addTokenTypeInAccountsESDT(tokensData, accountsESDTMap)
@@ -625,12 +590,12 @@ func (ei *elasticProcessor) saveAccountsESDT(
 		return err
 	}
 
-	err = ei.indexAccountsESDT(accountsESDTMap, updatesNFTsData)
+	err = ei.indexAccountsESDT(accountsESDTMap, updatesNFTsData, buffSlice)
 	if err != nil {
 		return err
 	}
 
-	return ei.saveAccountsESDTHistory(timestamp, accountsESDTMap)
+	return ei.saveAccountsESDTHistory(timestamp, accountsESDTMap, buffSlice)
 }
 
 func (ei *elasticProcessor) addTokenTypeInAccountsESDT(tokensData data.TokensHandler, accountsESDTMap map[string]*data.AccountInfo) error {
@@ -650,37 +615,28 @@ func (ei *elasticProcessor) addTokenTypeInAccountsESDT(tokensData data.TokensHan
 	return nil
 }
 
-func (ei *elasticProcessor) prepareAndIndexTagsCount(tagsCount data.CountTags) error {
+func (ei *elasticProcessor) prepareAndIndexTagsCount(tagsCount data.CountTags, buffSlice *data.BufferSlice) error {
 	shouldSkipIndex := !ei.isIndexEnabled(elasticIndexer.TagsIndex) || tagsCount.Len() == 0
 	if shouldSkipIndex {
 		return nil
 	}
 
-	serializedTags, err := tagsCount.Serialize()
-	if err != nil {
-		return err
-	}
-
-	return ei.doBulkRequests(elasticIndexer.TagsIndex, serializedTags)
+	return tagsCount.Serialize(buffSlice, elasticIndexer.TagsIndex)
 }
 
 func (ei *elasticProcessor) indexAccountsESDT(
 	accountsESDTMap map[string]*data.AccountInfo,
 	updatesNFTsData []*data.NFTDataUpdate,
+	buffSlice *data.BufferSlice,
 ) error {
 	if !ei.isIndexEnabled(elasticIndexer.AccountsESDTIndex) {
 		return nil
 	}
 
-	buffSlice, err := ei.accountsProc.SerializeAccountsESDT(accountsESDTMap, updatesNFTsData)
-	if err != nil {
-		return err
-	}
-
-	return ei.doBulkRequests(elasticIndexer.AccountsESDTIndex, buffSlice)
+	return ei.accountsProc.SerializeAccountsESDT(accountsESDTMap, updatesNFTsData, buffSlice, elasticIndexer.AccountsESDTIndex)
 }
 
-func (ei *elasticProcessor) indexNFTCreateInfo(tokensData data.TokensHandler) error {
+func (ei *elasticProcessor) indexNFTCreateInfo(tokensData data.TokensHandler, buffSlice *data.BufferSlice) error {
 	shouldSkipIndex := !ei.isIndexEnabled(elasticIndexer.TokensIndex) || tokensData.Len() == 0
 	if shouldSkipIndex {
 		return nil
@@ -697,15 +653,10 @@ func (ei *elasticProcessor) indexNFTCreateInfo(tokensData data.TokensHandler) er
 	tokens := tokensData.GetAll()
 	ei.accountsProc.PutTokenMedataDataInTokens(tokens)
 
-	buffSlice, err := ei.accountsProc.SerializeNFTCreateInfo(tokens)
-	if err != nil {
-		return err
-	}
-
-	return ei.doBulkRequests(elasticIndexer.TokensIndex, buffSlice)
+	return ei.accountsProc.SerializeNFTCreateInfo(tokens, buffSlice, elasticIndexer.TokensIndex)
 }
 
-func (ei *elasticProcessor) indexNFTBurnInfo(tokensData data.TokensHandler) error {
+func (ei *elasticProcessor) indexNFTBurnInfo(tokensData data.TokensHandler, buffSlice *data.BufferSlice) error {
 	shouldSkipIndex := !ei.isIndexEnabled(elasticIndexer.TokensIndex) || tokensData.Len() == 0
 	if shouldSkipIndex {
 		return nil
@@ -719,95 +670,75 @@ func (ei *elasticProcessor) indexNFTBurnInfo(tokensData data.TokensHandler) erro
 
 	// TODO implement to keep in tokens also the supply
 	tokensData.AddTypeFromResponse(responseTokens)
-	buffSlice, err := ei.logsAndEventsProc.SerializeSupplyData(tokensData)
-	if err != nil {
-		return err
-	}
-
-	return ei.doBulkRequests(elasticIndexer.TokensIndex, buffSlice)
+	return ei.logsAndEventsProc.SerializeSupplyData(tokensData, buffSlice, elasticIndexer.TokensIndex)
 }
 
 // SaveAccounts will prepare and save information about provided accounts in elasticsearch server
 func (ei *elasticProcessor) SaveAccounts(timestamp uint64, accts []*data.Account) error {
-	accountsMap := ei.accountsProc.PrepareRegularAccountsMap(accts)
-	err := ei.indexAccounts(accountsMap, elasticIndexer.AccountsIndex)
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	return ei.saveAccounts(timestamp, accts, buffSlice)
+}
+
+func (ei *elasticProcessor) saveAccounts(timestamp uint64, accts []*data.Account, buffSlice *data.BufferSlice) error {
+	accountsMap := ei.accountsProc.PrepareRegularAccountsMap(timestamp, accts)
+	err := ei.indexAccounts(accountsMap, elasticIndexer.AccountsIndex, buffSlice)
 	if err != nil {
 		return err
 	}
 
-	return ei.saveAccountsHistory(timestamp, accountsMap)
+	return ei.saveAccountsHistory(timestamp, accountsMap, buffSlice)
 }
 
-func (ei *elasticProcessor) indexAccounts(accountsMap map[string]*data.AccountInfo, index string) error {
+func (ei *elasticProcessor) indexAccounts(accountsMap map[string]*data.AccountInfo, index string, buffSlice *data.BufferSlice) error {
 	if !ei.isIndexEnabled(index) {
 		return nil
 	}
 
-	return ei.serializeAndIndexAccounts(accountsMap, index)
+	return ei.serializeAndIndexAccounts(accountsMap, index, buffSlice)
 }
 
-func (ei *elasticProcessor) serializeAndIndexAccounts(accountsMap map[string]*data.AccountInfo, index string) error {
-	buffSlice, err := ei.accountsProc.SerializeAccounts(accountsMap)
-	if err != nil {
-		return err
-	}
-
-	return ei.doBulkRequests(index, buffSlice)
+func (ei *elasticProcessor) serializeAndIndexAccounts(accountsMap map[string]*data.AccountInfo, index string, buffSlice *data.BufferSlice) error {
+	return ei.accountsProc.SerializeAccounts(accountsMap, buffSlice, index)
 }
 
-func (ei *elasticProcessor) saveAccountsESDTHistory(timestamp uint64, accountsInfoMap map[string]*data.AccountInfo) error {
+func (ei *elasticProcessor) saveAccountsESDTHistory(timestamp uint64, accountsInfoMap map[string]*data.AccountInfo, buffSlice *data.BufferSlice) error {
 	if !ei.isIndexEnabled(elasticIndexer.AccountsESDTHistoryIndex) {
 		return nil
 	}
 
 	accountsMap := ei.accountsProc.PrepareAccountsHistory(timestamp, accountsInfoMap)
 
-	return ei.serializeAndIndexAccountsHistory(accountsMap, elasticIndexer.AccountsESDTHistoryIndex)
+	return ei.serializeAndIndexAccountsHistory(accountsMap, elasticIndexer.AccountsESDTHistoryIndex, buffSlice)
 }
 
-func (ei *elasticProcessor) saveAccountsHistory(timestamp uint64, accountsInfoMap map[string]*data.AccountInfo) error {
+func (ei *elasticProcessor) saveAccountsHistory(timestamp uint64, accountsInfoMap map[string]*data.AccountInfo, buffSlice *data.BufferSlice) error {
 	if !ei.isIndexEnabled(elasticIndexer.AccountsHistoryIndex) {
 		return nil
 	}
 
 	accountsMap := ei.accountsProc.PrepareAccountsHistory(timestamp, accountsInfoMap)
 
-	return ei.serializeAndIndexAccountsHistory(accountsMap, elasticIndexer.AccountsHistoryIndex)
+	return ei.serializeAndIndexAccountsHistory(accountsMap, elasticIndexer.AccountsHistoryIndex, buffSlice)
 }
 
-func (ei *elasticProcessor) serializeAndIndexAccountsHistory(accountsMap map[string]*data.AccountBalanceHistory, index string) error {
-	buffSlice, err := ei.accountsProc.SerializeAccountsHistory(accountsMap)
-	if err != nil {
-		return err
-	}
-
-	return ei.doBulkRequests(index, buffSlice)
+func (ei *elasticProcessor) serializeAndIndexAccountsHistory(accountsMap map[string]*data.AccountBalanceHistory, index string, buffSlice *data.BufferSlice) error {
+	return ei.accountsProc.SerializeAccountsHistory(accountsMap, buffSlice, index)
 }
 
-func (ei *elasticProcessor) indexScResults(scrs []*data.ScResult) error {
+func (ei *elasticProcessor) indexScResults(scrs []*data.ScResult, buffSlice *data.BufferSlice) error {
 	if !ei.isIndexEnabled(elasticIndexer.ScResultsIndex) {
 		return nil
 	}
 
-	buffSlice, err := ei.transactionsProc.SerializeScResults(scrs)
-	if err != nil {
-		return err
-	}
-
-	return ei.doBulkRequests(elasticIndexer.ScResultsIndex, buffSlice)
+	return ei.transactionsProc.SerializeScResults(scrs, buffSlice, elasticIndexer.ScResultsIndex)
 }
 
-func (ei *elasticProcessor) indexReceipts(receipts []*data.Receipt) error {
+func (ei *elasticProcessor) indexReceipts(receipts []*data.Receipt, buffSlice *data.BufferSlice) error {
 	if !ei.isIndexEnabled(elasticIndexer.ReceiptsIndex) {
 		return nil
 	}
 
-	buffSlice, err := ei.transactionsProc.SerializeReceipts(receipts)
-	if err != nil {
-		return err
-	}
-
-	return ei.doBulkRequests(elasticIndexer.ReceiptsIndex, buffSlice)
+	return ei.transactionsProc.SerializeReceipts(receipts, buffSlice, elasticIndexer.ReceiptsIndex)
 }
 
 func (ei *elasticProcessor) isIndexEnabled(index string) bool {

--- a/process/interface.go
+++ b/process/interface.go
@@ -30,16 +30,16 @@ type DatabaseClientHandler interface {
 // DBAccountHandler defines the actions that an accounts handler should do
 type DBAccountHandler interface {
 	GetAccounts(alteredAccounts data.AlteredAccountsHandler) ([]*data.Account, []*data.AccountESDT)
-	PrepareRegularAccountsMap(accounts []*data.Account) map[string]*data.AccountInfo
+	PrepareRegularAccountsMap(timestamp uint64, accounts []*data.Account) map[string]*data.AccountInfo
 	PrepareAccountsMapESDT(timestamp uint64, accounts []*data.AccountESDT) (map[string]*data.AccountInfo, data.TokensHandler)
 	PrepareAccountsHistory(timestamp uint64, accounts map[string]*data.AccountInfo) map[string]*data.AccountBalanceHistory
 	PutTokenMedataDataInTokens(tokensData []*data.TokenInfo)
 
-	SerializeAccountsHistory(accounts map[string]*data.AccountBalanceHistory) ([]*bytes.Buffer, error)
-	SerializeAccounts(accounts map[string]*data.AccountInfo) ([]*bytes.Buffer, error)
-	SerializeAccountsESDT(accounts map[string]*data.AccountInfo, updateNFTData []*data.NFTDataUpdate) ([]*bytes.Buffer, error)
-	SerializeNFTCreateInfo(tokensInfo []*data.TokenInfo) ([]*bytes.Buffer, error)
-	SerializeTypeForProvidedIDs(ids []string, tokenType string) ([]*bytes.Buffer, error)
+	SerializeAccountsHistory(accounts map[string]*data.AccountBalanceHistory, buffSlice *data.BufferSlice, index string) error
+	SerializeAccounts(accounts map[string]*data.AccountInfo, buffSlice *data.BufferSlice, index string) error
+	SerializeAccountsESDT(accounts map[string]*data.AccountInfo, updateNFTData []*data.NFTDataUpdate, buffSlice *data.BufferSlice, index string) error
+	SerializeNFTCreateInfo(tokensInfo []*data.TokenInfo, buffSlice *data.BufferSlice, index string) error
+	SerializeTypeForProvidedIDs(ids []string, tokenType string, buffSlice *data.BufferSlice, index string) error
 }
 
 // DBBlockHandler defines the actions that a block handler should do
@@ -54,8 +54,8 @@ type DBBlockHandler interface {
 	) (*data.Block, error)
 	ComputeHeaderHash(header coreData.HeaderHandler) ([]byte, error)
 
-	SerializeEpochInfoData(header coreData.HeaderHandler) (*bytes.Buffer, error)
-	SerializeBlock(elasticBlock *data.Block) (*bytes.Buffer, error)
+	SerializeEpochInfoData(header coreData.HeaderHandler, buffSlice *data.BufferSlice, index string) error
+	SerializeBlock(elasticBlock *data.Block, buffSlice *data.BufferSlice, index string) error
 }
 
 // DBTransactionsHandler defines the actions that a transactions handler should do
@@ -67,10 +67,10 @@ type DBTransactionsHandler interface {
 	) *data.PreparedResults
 	GetRewardsTxsHashesHexEncoded(header coreData.HeaderHandler, body *block.Body) []string
 
-	SerializeReceipts(receipts []*data.Receipt) ([]*bytes.Buffer, error)
-	SerializeTransactions(transactions []*data.Transaction, txHashStatus map[string]string, selfShardID uint32) ([]*bytes.Buffer, error)
-	SerializeTransactionWithRefund(txs map[string]*data.Transaction, txHashRefund map[string]*data.RefundData) ([]*bytes.Buffer, error)
-	SerializeScResults(scResults []*data.ScResult) ([]*bytes.Buffer, error)
+	SerializeReceipts(receipts []*data.Receipt, buffSlice *data.BufferSlice, index string) error
+	SerializeTransactions(transactions []*data.Transaction, txHashStatus map[string]string, selfShardID uint32, buffSlice *data.BufferSlice, index string) error
+	SerializeTransactionWithRefund(txs map[string]*data.Transaction, txHashRefund map[string]*data.RefundData, buffSlice *data.BufferSlice, index string) error
+	SerializeScResults(scResults []*data.ScResult, buffSlice *data.BufferSlice, index string) error
 }
 
 // DBMiniblocksHandler defines the actions that a miniblocks handler should do
@@ -78,7 +78,7 @@ type DBMiniblocksHandler interface {
 	PrepareDBMiniblocks(header coreData.HeaderHandler, body *block.Body) []*data.Miniblock
 	GetMiniblocksHashesHexEncoded(header coreData.HeaderHandler, body *block.Body) []string
 
-	SerializeBulkMiniBlocks(bulkMbs []*data.Miniblock, mbsInDB map[string]bool) *bytes.Buffer
+	SerializeBulkMiniBlocks(bulkMbs []*data.Miniblock, mbsInDB map[string]bool, buffSlice *data.BufferSlice, index string)
 }
 
 // DBStatisticsHandler defines the actions that a database statistics handler should do
@@ -102,16 +102,16 @@ type DBLogsAndEventsHandler interface {
 		timestamp uint64,
 	) *data.PreparedLogsResults
 
-	SerializeLogs(logs []*data.Logs) ([]*bytes.Buffer, error)
-	SerializeSCDeploys(map[string]*data.ScDeployInfo) ([]*bytes.Buffer, error)
-	SerializeTokens(tokens []*data.TokenInfo, updateNFTData []*data.NFTDataUpdate) ([]*bytes.Buffer, error)
-	SerializeDelegators(delegators map[string]*data.Delegator) ([]*bytes.Buffer, error)
-	SerializeSupplyData(tokensSupply data.TokensHandler) ([]*bytes.Buffer, error)
-	SerializeRolesData(rolesData data.RolesData) ([]*bytes.Buffer, error)
+	SerializeLogs(logs []*data.Logs, buffSlice *data.BufferSlice, index string) error
+	SerializeSCDeploys(deploysInfo map[string]*data.ScDeployInfo, buffSlice *data.BufferSlice, index string) error
+	SerializeTokens(tokens []*data.TokenInfo, updateNFTData []*data.NFTDataUpdate, buffSlice *data.BufferSlice, index string) error
+	SerializeDelegators(delegators map[string]*data.Delegator, buffSlice *data.BufferSlice, index string) error
+	SerializeSupplyData(tokensSupply data.TokensHandler, buffSlice *data.BufferSlice, index string) error
+	SerializeRolesData(rolesData data.RolesData, buffSlice *data.BufferSlice, index string) error
 }
 
 // OperationsHandler defines the actions that an operations' handler should do
 type OperationsHandler interface {
 	ProcessTransactionsAndSCRs(txs []*data.Transaction, scrs []*data.ScResult) ([]*data.Transaction, []*data.ScResult)
-	SerializeSCRs(scrs []*data.ScResult) ([]*bytes.Buffer, error)
+	SerializeSCRs(scrs []*data.ScResult, buffSlice *data.BufferSlice, index string) error
 }

--- a/process/logsevents/serialize.go
+++ b/process/logsevents/serialize.go
@@ -1,7 +1,6 @@
 package logsevents
 
 import (
-	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -12,42 +11,40 @@ import (
 )
 
 // SerializeLogs will serialize the provided logs in a way that Elastic Search expects a bulk request
-func (logsAndEventsProcessor) SerializeLogs(logs []*data.Logs) ([]*bytes.Buffer, error) {
-	buffSlice := data.NewBufferSlice()
-	for _, log := range logs {
-		meta := []byte(fmt.Sprintf(`{ "index" : { "_id" : "%s" } }%s`, log.ID, "\n"))
-		serializedData, errMarshal := json.Marshal(log)
+func (logsAndEventsProcessor) SerializeLogs(logs []*data.Logs, buffSlice *data.BufferSlice, index string) error {
+	for _, lg := range logs {
+		meta := []byte(fmt.Sprintf(`{ "index" : {"_index":"%s", "_id" : "%s" } }%s`, index, lg.ID, "\n"))
+		serializedData, errMarshal := json.Marshal(lg)
 		if errMarshal != nil {
-			return nil, errMarshal
+			return errMarshal
 		}
 
 		err := buffSlice.PutData(meta, serializedData)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return buffSlice.Buffers(), nil
+	return nil
 }
 
 // SerializeSCDeploys will serialize the provided smart contract deploys in a way that Elastic Search expects a bulk request
-func (logsAndEventsProcessor) SerializeSCDeploys(deploys map[string]*data.ScDeployInfo) ([]*bytes.Buffer, error) {
-	buffSlice := data.NewBufferSlice()
+func (logsAndEventsProcessor) SerializeSCDeploys(deploys map[string]*data.ScDeployInfo, buffSlice *data.BufferSlice, index string) error {
 	for scAddr, deployInfo := range deploys {
-		meta := []byte(fmt.Sprintf(`{ "update" : { "_id" : "%s", "_type" : "_doc" } }%s`, scAddr, "\n"))
+		meta := []byte(fmt.Sprintf(`{ "update" : { "_index":"%s", "_id" : "%s", "_type" : "_doc" } }%s`, index, scAddr, "\n"))
 
 		serializedData, err := serializeDeploy(deployInfo)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		err = buffSlice.PutData(meta, serializedData)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return buffSlice.Buffers(), nil
+	return nil
 }
 
 func serializeDeploy(deployInfo *data.ScDeployInfo) ([]byte, error) {
@@ -78,34 +75,28 @@ func serializeDeploy(deployInfo *data.ScDeployInfo) ([]byte, error) {
 }
 
 // SerializeTokens will serialize the provided tokens data in a way that Elastic Search expects a bulk request
-func (logsAndEventsProcessor) SerializeTokens(tokens []*data.TokenInfo, updateNFTData []*data.NFTDataUpdate) ([]*bytes.Buffer, error) {
-	buffSlice := data.NewBufferSlice()
+func (logsAndEventsProcessor) SerializeTokens(tokens []*data.TokenInfo, updateNFTData []*data.NFTDataUpdate, buffSlice *data.BufferSlice, index string) error {
 	for _, tokenData := range tokens {
-		meta, serializedData, err := serializeToken(tokenData)
+		meta, serializedData, err := serializeToken(tokenData, index)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		err = buffSlice.PutData(meta, serializedData)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	err := converters.PrepareNFTUpdateData(buffSlice, updateNFTData, false)
-	if err != nil {
-		return nil, err
-	}
-
-	return buffSlice.Buffers(), nil
+	return converters.PrepareNFTUpdateData(buffSlice, updateNFTData, false, index)
 }
 
-func serializeToken(tokenData *data.TokenInfo) ([]byte, []byte, error) {
+func serializeToken(tokenData *data.TokenInfo, index string) ([]byte, []byte, error) {
 	if tokenData.TransferOwnership {
-		return serializeTokenTransferOwnership(tokenData)
+		return serializeTokenTransferOwnership(tokenData, index)
 	}
 
-	meta := []byte(fmt.Sprintf(`{ "update" : { "_id" : "%s", "_type" : "_doc" } }%s`, tokenData.Token, "\n"))
+	meta := []byte(fmt.Sprintf(`{ "update" : { "_index":"%s", "_id" : "%s", "_type" : "_doc" } }%s`, index, tokenData.Token, "\n"))
 	serializedTokenData, err := json.Marshal(tokenData)
 	if err != nil {
 		return nil, nil, err
@@ -121,8 +112,8 @@ func serializeToken(tokenData *data.TokenInfo) ([]byte, []byte, error) {
 	return meta, []byte(serializedDataStr), nil
 }
 
-func serializeTokenTransferOwnership(tokenData *data.TokenInfo) ([]byte, []byte, error) {
-	meta := []byte(fmt.Sprintf(`{ "update" : { "_id" : "%s", "_type" : "_doc" } }%s`, tokenData.Token, "\n"))
+func serializeTokenTransferOwnership(tokenData *data.TokenInfo, index string) ([]byte, []byte, error) {
+	meta := []byte(fmt.Sprintf(`{ "update" : { "_index":"%s", "_id" : "%s", "_type" : "_doc" } }%s`, index, tokenData.Token, "\n"))
 	tokenDataSerialized, err := json.Marshal(tokenData)
 	if err != nil {
 		return nil, nil, err
@@ -149,31 +140,30 @@ func serializeTokenTransferOwnership(tokenData *data.TokenInfo) ([]byte, []byte,
 }
 
 // SerializeDelegators will serialize the provided delegators in a way that Elastic Search expects a bulk request
-func (lep *logsAndEventsProcessor) SerializeDelegators(delegators map[string]*data.Delegator) ([]*bytes.Buffer, error) {
-	buffSlice := data.NewBufferSlice()
+func (lep *logsAndEventsProcessor) SerializeDelegators(delegators map[string]*data.Delegator, buffSlice *data.BufferSlice, index string) error {
 	for _, delegator := range delegators {
-		meta, serializedData, err := lep.prepareSerializedDelegator(delegator)
+		meta, serializedData, err := lep.prepareSerializedDelegator(delegator, index)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		err = buffSlice.PutData(meta, serializedData)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return buffSlice.Buffers(), nil
+	return nil
 }
 
-func (lep *logsAndEventsProcessor) prepareSerializedDelegator(delegator *data.Delegator) ([]byte, []byte, error) {
+func (lep *logsAndEventsProcessor) prepareSerializedDelegator(delegator *data.Delegator, index string) ([]byte, []byte, error) {
 	id := lep.computeDelegatorID(delegator)
 	if delegator.ShouldDelete {
-		meta := []byte(fmt.Sprintf(`{ "delete" : { "_id" : "%s" } }%s`, id, "\n"))
+		meta := []byte(fmt.Sprintf(`{ "delete" : { "_index": "%s", "_id" : "%s" } }%s`, index, id, "\n"))
 		return meta, nil, nil
 	}
 
-	meta := []byte(fmt.Sprintf(`{ "index" : { "_id" : "%s" } }%s`, id, "\n"))
+	meta := []byte(fmt.Sprintf(`{ "index" : { "_index": "%s", "_id" : "%s" } }%s`, index, id, "\n"))
 	serializedData, errMarshal := json.Marshal(delegator)
 	if errMarshal != nil {
 		return nil, nil, errMarshal
@@ -191,40 +181,38 @@ func (lep *logsAndEventsProcessor) computeDelegatorID(delegator *data.Delegator)
 }
 
 // SerializeSupplyData will serialize the provided supply data
-func (lep *logsAndEventsProcessor) SerializeSupplyData(tokensSupply data.TokensHandler) ([]*bytes.Buffer, error) {
-	buffSlice := data.NewBufferSlice()
+func (lep *logsAndEventsProcessor) SerializeSupplyData(tokensSupply data.TokensHandler, buffSlice *data.BufferSlice, index string) error {
 	for _, supplyData := range tokensSupply.GetAll() {
 		if supplyData.Type != core.NonFungibleESDT {
 			continue
 		}
 
-		meta := []byte(fmt.Sprintf(`{ "delete" : { "_id" : "%s" } }%s`, supplyData.Identifier, "\n"))
+		meta := []byte(fmt.Sprintf(`{ "delete" : { "_index": "%s", "_id" : "%s" } }%s`, index, supplyData.Identifier, "\n"))
 		err := buffSlice.PutData(meta, nil)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return buffSlice.Buffers(), nil
+	return nil
 }
 
 // SerializeRolesData will serialize the provided roles data
-func (lep *logsAndEventsProcessor) SerializeRolesData(rolesData data.RolesData) ([]*bytes.Buffer, error) {
-	buffSlice := data.NewBufferSlice()
+func (lep *logsAndEventsProcessor) SerializeRolesData(rolesData data.RolesData, buffSlice *data.BufferSlice, index string) error {
 	for role, roleData := range rolesData {
 		for _, rd := range roleData {
-			err := serializeRoleData(buffSlice, rd, role)
+			err := serializeRoleData(buffSlice, rd, role, index)
 			if err != nil {
-				return nil, err
+				return err
 			}
 		}
 	}
 
-	return buffSlice.Buffers(), nil
+	return nil
 }
 
-func serializeRoleData(buffSlice *data.BufferSlice, rd *data.RoleData, role string) error {
-	meta := []byte(fmt.Sprintf(`{ "update" : { "_id" : "%s", "_type" : "_doc" } }%s`, rd.Token, "\n"))
+func serializeRoleData(buffSlice *data.BufferSlice, rd *data.RoleData, role string, index string) error {
+	meta := []byte(fmt.Sprintf(`{ "update" : {"_index": "%s", "_id" : "%s", "_type" : "_doc" } }%s`, index, rd.Token, "\n"))
 	var serializedDataStr string
 	if rd.Set {
 		serializedDataStr = fmt.Sprintf(`{"script": {`+

--- a/process/logsevents/serialize_test.go
+++ b/process/logsevents/serialize_test.go
@@ -31,13 +31,14 @@ func TestLogsAndEventsProcessor_SerializeLogs(t *testing.T) {
 		},
 	}
 
-	res, err := (&logsAndEventsProcessor{}).SerializeLogs(logs)
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := (&logsAndEventsProcessor{}).SerializeLogs(logs, buffSlice, "logs")
 	require.Nil(t, err)
 
-	expectedRes := `{ "index" : { "_id" : "747848617368" } }
+	expectedRes := `{ "index" : {"_index":"logs", "_id" : "747848617368" } }
 {"address":"61646472657373","events":[{"address":"61646472","identifier":"ESDTNFTTransfer","topics":["bXktdG9rZW4=","AQ==","cmVjZWl2ZXI="],"data":"ZGF0YQ==","order":0}],"timestamp":1234}
 `
-	require.Equal(t, expectedRes, res[0].String())
+	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
 }
 
 func TestLogsAndEventsProcessor_SerializeSCDeploys(t *testing.T) {
@@ -51,13 +52,14 @@ func TestLogsAndEventsProcessor_SerializeSCDeploys(t *testing.T) {
 		},
 	}
 
-	res, err := (&logsAndEventsProcessor{}).SerializeSCDeploys(scDeploys)
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := (&logsAndEventsProcessor{}).SerializeSCDeploys(scDeploys, buffSlice, "scdeploys")
 	require.Nil(t, err)
 
-	expectedRes := `{ "update" : { "_id" : "scAddr", "_type" : "_doc" } }
+	expectedRes := `{ "update" : { "_index":"scdeploys", "_id" : "scAddr", "_type" : "_doc" } }
 {"script": {"source": "if (!ctx._source.containsKey('upgrades')) { ctx._source.upgrades = [ params.elem ]; } else {  ctx._source.upgrades.add(params.elem); }","lang": "painless","params": {"elem": {"upgradeTxHash":"hash","upgrader":"creator","timestamp":123}}},"upsert": {"deployTxHash":"hash","deployer":"creator","timestamp":123,"upgrades":[]}}
 `
-	require.Equal(t, expectedRes, res[0].String())
+	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
 }
 
 func TestSerializeTokens(t *testing.T) {
@@ -96,16 +98,17 @@ func TestSerializeTokens(t *testing.T) {
 	}
 	tokens := []*data.TokenInfo{tok1, tok2}
 
-	res, err := (&logsAndEventsProcessor{}).SerializeTokens(tokens, nil)
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := (&logsAndEventsProcessor{}).SerializeTokens(tokens, nil, buffSlice, "tokens")
 	require.Nil(t, err)
-	require.Equal(t, 1, len(res))
+	require.Equal(t, 1, len(buffSlice.Buffers()))
 
-	expectedRes := `{ "update" : { "_id" : "TKN-01234", "_type" : "_doc" } }
+	expectedRes := `{ "update" : { "_index":"tokens", "_id" : "TKN-01234", "_type" : "_doc" } }
 {"script": {"source": "if (ctx._source.containsKey('roles')) {HashMap roles = ctx._source.roles; ctx._source = params.token; ctx._source.roles = roles}","lang": "painless","params": {"token": {"name":"TokenName","ticker":"TKN","token":"TKN-01234","issuer":"erd123","currentOwner":"erd123","type":"SemiFungibleESDT","timestamp":50000,"ownersHistory":[{"address":"erd123","timestamp":50000}]}}},"upsert": {"name":"TokenName","ticker":"TKN","token":"TKN-01234","issuer":"erd123","currentOwner":"erd123","type":"SemiFungibleESDT","timestamp":50000,"ownersHistory":[{"address":"erd123","timestamp":50000}]}}
-{ "update" : { "_id" : "TKN2-51234", "_type" : "_doc" } }
+{ "update" : { "_index":"tokens", "_id" : "TKN2-51234", "_type" : "_doc" } }
 {"script": {"source": "if (!ctx._source.containsKey('ownersHistory')) { ctx._source.ownersHistory = [ params.elem ] } else { ctx._source.ownersHistory.add(params.elem) } ctx._source.currentOwner = params.owner ","lang": "painless","params": {"elem": {"address":"abde123456","timestamp":60000}, "owner": "abde123456"}},"upsert": {"name":"Token2","ticker":"TKN2","token":"TKN2-51234","issuer":"erd1231213123","currentOwner":"abde123456","type":"NonFungibleESDT","timestamp":60000,"ownersHistory":[{"address":"abde123456","timestamp":60000}]}}
 `
-	require.Equal(t, expectedRes, res[0].String())
+	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
 }
 
 func TestLogsAndEventsProcessor_SerializeDelegators(t *testing.T) {
@@ -126,13 +129,14 @@ func TestLogsAndEventsProcessor_SerializeDelegators(t *testing.T) {
 		hasher: &mock.HasherMock{},
 	}
 
-	res, err := logsProc.SerializeDelegators(delegators)
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := logsProc.SerializeDelegators(delegators, buffSlice, "delegators")
 	require.Nil(t, err)
 
-	expectedRes := `{ "index" : { "_id" : "/GeogJjDjtpxnceK9t6+BVBYWuuJHbjmsWK0/1BlH9c=" } }
+	expectedRes := `{ "index" : { "_index": "delegators", "_id" : "/GeogJjDjtpxnceK9t6+BVBYWuuJHbjmsWK0/1BlH9c=" } }
 {"address":"addr1","contract":"contract1","activeStake":"100000000000000","activeStakeNum":0.1}
 `
-	require.Equal(t, expectedRes, res[0].String())
+	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
 }
 
 func TestLogsAndEventsProcessor_SerializeDelegatorsDelete(t *testing.T) {
@@ -152,10 +156,11 @@ func TestLogsAndEventsProcessor_SerializeDelegatorsDelete(t *testing.T) {
 		hasher: &mock.HasherMock{},
 	}
 
-	res, err := logsProc.SerializeDelegators(delegators)
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := logsProc.SerializeDelegators(delegators, buffSlice, "delegators")
 	require.Nil(t, err)
 
-	expectedRes := `{ "delete" : { "_id" : "/GeogJjDjtpxnceK9t6+BVBYWuuJHbjmsWK0/1BlH9c=" } }
+	expectedRes := `{ "delete" : { "_index": "delegators", "_id" : "/GeogJjDjtpxnceK9t6+BVBYWuuJHbjmsWK0/1BlH9c=" } }
 `
-	require.Equal(t, expectedRes, res[0].String())
+	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
 }

--- a/process/miniblocks/serialize.go
+++ b/process/miniblocks/serialize.go
@@ -1,7 +1,6 @@
 package miniblocks
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -12,35 +11,34 @@ import (
 func (mp *miniblocksProcessor) SerializeBulkMiniBlocks(
 	bulkMbs []*data.Miniblock,
 	existsInDb map[string]bool,
-) *bytes.Buffer {
-	buff := &bytes.Buffer{}
+	buffSlice *data.BufferSlice,
+	index string,
+) {
 	for _, mb := range bulkMbs {
-		meta, serializedData, err := mp.prepareMiniblockData(mb, existsInDb[mb.Hash])
+		meta, serializedData, err := mp.prepareMiniblockData(mb, existsInDb[mb.Hash], index)
 		if err != nil {
 			log.Warn("miniblocksProcessor.prepareMiniblockData cannot prepare miniblock data", "error", err)
 			continue
 		}
 
-		err = putInBufferMiniblockData(buff, meta, serializedData)
+		err = buffSlice.PutData(meta, serializedData)
 		if err != nil {
 			log.Warn("miniblocksProcessor.putInBufferMiniblockData cannot prepare miniblock data", "error", err)
 			continue
 		}
 	}
-
-	return buff
 }
 
-func (mp *miniblocksProcessor) prepareMiniblockData(miniblockDB *data.Miniblock, isInDB bool) ([]byte, []byte, error) {
+func (mp *miniblocksProcessor) prepareMiniblockData(miniblockDB *data.Miniblock, isInDB bool, index string) ([]byte, []byte, error) {
 	if !isInDB {
-		meta := []byte(fmt.Sprintf(`{ "index" : { "_id" : "%s", "_type" : "%s" } }%s`, miniblockDB.Hash, "_doc", "\n"))
+		meta := []byte(fmt.Sprintf(`{ "index" : { "_index":"%s", "_id" : "%s"} }%s`, index, miniblockDB.Hash, "\n"))
 		serializedData, err := json.Marshal(miniblockDB)
 
 		return meta, serializedData, err
 	}
 
 	// prepare data for update operation
-	meta := []byte(fmt.Sprintf(`{ "update" : { "_id" : "%s" } }%s`, miniblockDB.Hash, "\n"))
+	meta := []byte(fmt.Sprintf(`{ "update" : {"_index":"%s", "_id" : "%s" } }%s`, index, miniblockDB.Hash, "\n"))
 	if mp.selfShardID == miniblockDB.SenderShardID {
 		// prepare for update sender block hash
 		serializedData := []byte(fmt.Sprintf(`{ "doc" : { "senderBlockHash" : "%s", "procTypeS": "%s" } }`, miniblockDB.SenderBlockHash, miniblockDB.ProcessingTypeOnSource))
@@ -52,20 +50,4 @@ func (mp *miniblocksProcessor) prepareMiniblockData(miniblockDB *data.Miniblock,
 	serializedData := []byte(fmt.Sprintf(`{ "doc" : { "receiverBlockHash" : "%s", "procTypeD": "%s" } }`, miniblockDB.ReceiverBlockHash, miniblockDB.ProcessingTypeOnDestination))
 
 	return meta, serializedData, nil
-}
-
-func putInBufferMiniblockData(buff *bytes.Buffer, meta, serializedData []byte) error {
-	serializedData = append(serializedData, "\n"...)
-	buff.Grow(len(meta) + len(serializedData))
-	_, err := buff.Write(meta)
-	if err != nil {
-		return err
-	}
-
-	_, err = buff.Write(serializedData)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/process/miniblocks/serialize_test.go
+++ b/process/miniblocks/serialize_test.go
@@ -18,14 +18,15 @@ func TestMiniblocksProcessor_SerializeBulkMiniBlocks(t *testing.T) {
 		{Hash: "h2", SenderShardID: 0, ReceiverShardID: 2},
 	}
 
-	buff := mp.SerializeBulkMiniBlocks(miniblocks, nil)
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	mp.SerializeBulkMiniBlocks(miniblocks, nil, buffSlice, "miniblocks")
 
-	expectedBuff := `{ "index" : { "_id" : "h1", "_type" : "_doc" } }
+	expectedBuff := `{ "index" : { "_index":"miniblocks", "_id" : "h1"} }
 {"senderShard":0,"receiverShard":1,"senderBlockHash":"","receiverBlockHash":"","type":"","timestamp":0}
-{ "index" : { "_id" : "h2", "_type" : "_doc" } }
+{ "index" : { "_index":"miniblocks", "_id" : "h2"} }
 {"senderShard":0,"receiverShard":2,"senderBlockHash":"","receiverBlockHash":"","type":"","timestamp":0}
 `
-	require.Equal(t, expectedBuff, buff.String())
+	require.Equal(t, expectedBuff, buffSlice.Buffers()[0].String())
 }
 
 func TestMiniblocksProcessor_SerializeBulkMiniBlocksInDB(t *testing.T) {
@@ -38,14 +39,15 @@ func TestMiniblocksProcessor_SerializeBulkMiniBlocksInDB(t *testing.T) {
 		{Hash: "h2", SenderShardID: 0, ReceiverShardID: 2},
 	}
 
-	buff := mp.SerializeBulkMiniBlocks(miniblocks, map[string]bool{
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	mp.SerializeBulkMiniBlocks(miniblocks, map[string]bool{
 		"h1": true,
-	})
+	}, buffSlice, "miniblocks")
 
-	expectedBuff := `{ "update" : { "_id" : "h1" } }
+	expectedBuff := `{ "update" : {"_index":"miniblocks", "_id" : "h1" } }
 { "doc" : { "senderBlockHash" : "", "procTypeS": "" } }
-{ "index" : { "_id" : "h2", "_type" : "_doc" } }
+{ "index" : { "_index":"miniblocks", "_id" : "h2"} }
 {"senderShard":0,"receiverShard":2,"senderBlockHash":"","receiverBlockHash":"","type":"","timestamp":0}
 `
-	require.Equal(t, expectedBuff, buff.String())
+	require.Equal(t, expectedBuff, buffSlice.Buffers()[0].String())
 }

--- a/process/operations/serialize.go
+++ b/process/operations/serialize.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -9,28 +8,27 @@ import (
 )
 
 // SerializeSCRs will serialize smart contract results
-func (op *operationsProcessor) SerializeSCRs(scrs []*data.ScResult) ([]*bytes.Buffer, error) {
-	buffSlice := data.NewBufferSlice()
-
+func (op *operationsProcessor) SerializeSCRs(scrs []*data.ScResult, buffSlice *data.BufferSlice, index string) error {
 	for _, scr := range scrs {
-		meta, serializedData, err := op.prepareSerializedDataForAScResult(scr)
+		meta, serializedData, err := op.prepareSerializedDataForAScResult(scr, index)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		err = buffSlice.PutData(meta, serializedData)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return buffSlice.Buffers(), nil
+	return nil
 }
 
 func (op *operationsProcessor) prepareSerializedDataForAScResult(
 	scr *data.ScResult,
+	index string,
 ) ([]byte, []byte, error) {
-	metaData := []byte(fmt.Sprintf(`{"update":{"_id":"%s", "_type": "_doc"}}%s`, scr.Hash, "\n"))
+	metaData := []byte(fmt.Sprintf(`{"update":{"_index":"%s","_id":"%s", "_type": "_doc"}}%s`, index, scr.Hash, "\n"))
 	marshaledSCR, err := json.Marshal(scr)
 	if err != nil {
 		return nil, nil, err
@@ -46,7 +44,7 @@ func (op *operationsProcessor) prepareSerializedDataForAScResult(
 		return metaData, serializedData, nil
 	}
 
-	meta := []byte(fmt.Sprintf(`{ "index" : { "_id" : "%s", "_type" : "%s" } }%s`, scr.Hash, "_doc", "\n"))
+	meta := []byte(fmt.Sprintf(`{ "index" : { "_index":"%s","_id" : "%s", "_type" : "%s" } }%s`, index, scr.Hash, "_doc", "\n"))
 
 	return meta, marshaledSCR, nil
 }

--- a/process/operations/serialize_test.go
+++ b/process/operations/serialize_test.go
@@ -24,11 +24,12 @@ func TestOperationsProcessor_SerializeSCRS(t *testing.T) {
 		},
 	}
 
-	res, err := op.SerializeSCRs(scrs)
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := op.SerializeSCRs(scrs, buffSlice, "operations")
 	require.Nil(t, err)
-	require.Equal(t, `{"update":{"_id":"", "_type": "_doc"}}
+	require.Equal(t, `{"update":{"_index":"operations","_id":"", "_type": "_doc"}}
 {"script":{"source":"return"},"upsert":{"nonce":0,"gasLimit":0,"gasPrice":0,"value":"","sender":"","receiver":"","senderShard":0,"receiverShard":1,"prevTxHash":"","originalTxHash":"","callType":"","timestamp":0}}
-{ "index" : { "_id" : "", "_type" : "_doc" } }
+{ "index" : { "_index":"operations","_id" : "", "_type" : "_doc" } }
 {"nonce":0,"gasLimit":0,"gasPrice":0,"value":"","sender":"","receiver":"","senderShard":2,"receiverShard":0,"prevTxHash":"","originalTxHash":"","callType":"","timestamp":0}
-`, res[0].String())
+`, buffSlice.Buffers()[0].String())
 }

--- a/process/tags/serialize_test.go
+++ b/process/tags/serialize_test.go
@@ -1,6 +1,7 @@
 package tags
 
 import (
+	"github.com/ElrondNetwork/elastic-indexer-go/data"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,11 +15,12 @@ func TestTagsCount_Serialize(t *testing.T) {
 	tagsC.ParseTags([]string{"Art"})
 	tagsC.ParseTags([]string{"Art"})
 
-	buff, err := tagsC.Serialize()
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := tagsC.Serialize(buffSlice, "tags")
 	require.Nil(t, err)
 
-	expected := `{ "update" : { "_id" : "QXJ0", "_type" : "_doc" } }
+	expected := `{ "update" : {"_index":"tags", "_id" : "QXJ0", "_type" : "_doc" } }
 {"script": {"source": "ctx._source.count += params.count","lang": "painless","params": {"count": 2}},"upsert": {"count": 2}}
 `
-	require.Equal(t, expected, buff[0].String())
+	require.Equal(t, expected, buffSlice.Buffers()[0].String())
 }

--- a/process/transactions/serialize.go
+++ b/process/transactions/serialize.go
@@ -1,7 +1,6 @@
 package transactions
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -12,49 +11,48 @@ import (
 )
 
 // SerializeScResults will serialize the provided smart contract results in a way that Elastic Search expects a bulk request
-func (tdp *txsDatabaseProcessor) SerializeScResults(scResults []*data.ScResult) ([]*bytes.Buffer, error) {
-	buffSlice := data.NewBufferSlice()
+func (tdp *txsDatabaseProcessor) SerializeScResults(scResults []*data.ScResult, buffSlice *data.BufferSlice, index string) error {
 	for _, sc := range scResults {
-		meta := []byte(fmt.Sprintf(`{ "index" : { "_id" : "%s" } }%s`, sc.Hash, "\n"))
+		meta := []byte(fmt.Sprintf(`{ "index" : { "_index": "%s", "_id" : "%s" } }%s`, index, sc.Hash, "\n"))
 		serializedData, errPrepareSc := json.Marshal(sc)
 		if errPrepareSc != nil {
-			return nil, errPrepareSc
+			return errPrepareSc
 		}
 
 		err := buffSlice.PutData(meta, serializedData)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return buffSlice.Buffers(), nil
+	return nil
 }
 
 // SerializeReceipts will serialize the receipts in a way that Elastic Search expects a bulk request
-func (tdp *txsDatabaseProcessor) SerializeReceipts(receipts []*data.Receipt) ([]*bytes.Buffer, error) {
-	buffSlice := data.NewBufferSlice()
+func (tdp *txsDatabaseProcessor) SerializeReceipts(receipts []*data.Receipt, buffSlice *data.BufferSlice, index string) error {
 	for _, rec := range receipts {
-		meta := []byte(fmt.Sprintf(`{ "index" : { "_id" : "%s" } }%s`, rec.Hash, "\n"))
+		meta := []byte(fmt.Sprintf(`{ "index" : { "_index": "%s", "_id" : "%s" } }%s`, index, rec.Hash, "\n"))
 		serializedData, errPrepareReceipt := json.Marshal(rec)
 		if errPrepareReceipt != nil {
-			return nil, errPrepareReceipt
+			return errPrepareReceipt
 		}
 
 		err := buffSlice.PutData(meta, serializedData)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return buffSlice.Buffers(), nil
+	return nil
 }
 
 // SerializeTransactionWithRefund will serialize transaction based on refund
 func (tdp *txsDatabaseProcessor) SerializeTransactionWithRefund(
 	txs map[string]*data.Transaction,
 	txHashRefund map[string]*data.RefundData,
-) ([]*bytes.Buffer, error) {
-	buffSlice := data.NewBufferSlice()
+	buffSlice *data.BufferSlice,
+	index string,
+) error {
 	for txHash, tx := range txs {
 		refundForTx, ok := txHashRefund[txHash]
 		if !ok {
@@ -73,19 +71,19 @@ func (tdp *txsDatabaseProcessor) SerializeTransactionWithRefund(
 		tx.GasUsed = gasUsed
 		tx.Fee = fee.String()
 
-		meta := []byte(fmt.Sprintf(`{ "index" : { "_id" : "%s" } }%s`, txHash, "\n"))
+		meta := []byte(fmt.Sprintf(`{ "index" : { "_index": "%s", "_id" : "%s" } }%s`, index, txHash, "\n"))
 		serializedData, errPrepare := json.Marshal(tx)
 		if errPrepare != nil {
-			return nil, errPrepare
+			return errPrepare
 		}
 
 		err := buffSlice.PutData(meta, serializedData)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return buffSlice.Buffers(), nil
+	return nil
 }
 
 // SerializeTransactions will serialize the transactions in a way that Elastic Search expects a bulk request
@@ -93,31 +91,32 @@ func (tdp *txsDatabaseProcessor) SerializeTransactions(
 	transactions []*data.Transaction,
 	txHashStatus map[string]string,
 	selfShardID uint32,
-) ([]*bytes.Buffer, error) {
-	buffSlice := data.NewBufferSlice()
+	buffSlice *data.BufferSlice,
+	index string,
+) error {
 	for _, tx := range transactions {
-		meta, serializedData, err := prepareSerializedDataForATransaction(tx, selfShardID)
+		meta, serializedData, err := prepareSerializedDataForATransaction(tx, selfShardID, index)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		err = buffSlice.PutData(meta, serializedData)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	err := serializeTxHashStatus(buffSlice, txHashStatus)
+	err := serializeTxHashStatus(buffSlice, txHashStatus, index)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return buffSlice.Buffers(), nil
+	return nil
 }
 
-func serializeTxHashStatus(buffSlice *data.BufferSlice, txHashStatus map[string]string) error {
+func serializeTxHashStatus(buffSlice *data.BufferSlice, txHashStatus map[string]string, index string) error {
 	for txHash, status := range txHashStatus {
-		metaData := []byte(fmt.Sprintf(`{"update":{"_id":"%s", "_type": "_doc"}}%s`, txHash, "\n"))
+		metaData := []byte(fmt.Sprintf(`{"update":{ "_index":"%s","_id":"%s", "_type": "_doc"}}%s`, index, txHash, "\n"))
 
 		newTx := &data.Transaction{
 			Status: status,
@@ -140,8 +139,9 @@ func serializeTxHashStatus(buffSlice *data.BufferSlice, txHashStatus map[string]
 func prepareSerializedDataForATransaction(
 	tx *data.Transaction,
 	selfShardID uint32,
+	index string,
 ) ([]byte, []byte, error) {
-	metaData := []byte(fmt.Sprintf(`{"update":{"_id":"%s", "_type": "_doc"}}%s`, tx.Hash, "\n"))
+	metaData := []byte(fmt.Sprintf(`{"update":{ "_index":"%s", "_id":"%s", "_type": "_doc"}}%s`, index, tx.Hash, "\n"))
 	marshaledTx, err := json.Marshal(tx)
 	if err != nil {
 		return nil, nil, err
@@ -167,7 +167,7 @@ func prepareSerializedDataForATransaction(
 	}
 
 	// transaction is intra-shard, invalid or cross-shard destination me
-	meta := []byte(fmt.Sprintf(`{ "index" : { "_id" : "%s", "_type" : "%s" } }%s`, tx.Hash, "_doc", "\n"))
+	meta := []byte(fmt.Sprintf(`{ "index" : { "_index":"%s", "_id" : "%s", "_type" : "%s" } }%s`, index, tx.Hash, "_doc", "\n"))
 	log.Trace("indexer tx is intra shard or invalid tx", "meta", string(meta), "marshaledTx", string(marshaledTx))
 
 	return meta, marshaledTx, nil

--- a/process/transactions/serialize_test.go
+++ b/process/transactions/serialize_test.go
@@ -29,16 +29,17 @@ func TestSerializeScResults(t *testing.T) {
 	}
 	scrs := []*data.ScResult{scResult1, scResult2}
 
-	res, err := (&txsDatabaseProcessor{}).SerializeScResults(scrs)
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := (&txsDatabaseProcessor{}).SerializeScResults(scrs, buffSlice, "transactions")
 	require.Nil(t, err)
-	require.Equal(t, 1, len(res))
+	require.Equal(t, 1, len(buffSlice.Buffers()))
 
-	expectedRes := `{ "index" : { "_id" : "hash1" } }
+	expectedRes := `{ "index" : { "_index": "transactions", "_id" : "hash1" } }
 {"nonce":1,"gasLimit":50,"gasPrice":10,"value":"","sender":"","receiver":"","senderShard":0,"receiverShard":1,"prevTxHash":"","originalTxHash":"","callType":"","timestamp":0}
-{ "index" : { "_id" : "hash2" } }
+{ "index" : { "_index": "transactions", "_id" : "hash2" } }
 {"nonce":2,"gasLimit":50,"gasPrice":10,"value":"","sender":"","receiver":"","senderShard":2,"receiverShard":3,"prevTxHash":"","originalTxHash":"","callType":"","timestamp":0}
 `
-	require.Equal(t, expectedRes, res[0].String())
+	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
 }
 
 func TestSerializeReceipts(t *testing.T) {
@@ -57,67 +58,71 @@ func TestSerializeReceipts(t *testing.T) {
 
 	recs := []*data.Receipt{rec1, rec2}
 
-	res, err := (&txsDatabaseProcessor{}).SerializeReceipts(recs)
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := (&txsDatabaseProcessor{}).SerializeReceipts(recs, buffSlice, "receipts")
 	require.Nil(t, err)
-	require.Equal(t, 1, len(res))
+	require.Equal(t, 1, len(buffSlice.Buffers()))
 
-	expectedRes := `{ "index" : { "_id" : "recHash1" } }
+	expectedRes := `{ "index" : { "_index": "receipts", "_id" : "recHash1" } }
 {"value":"","sender":"sender1","txHash":"txHash1","timestamp":0}
-{ "index" : { "_id" : "recHash2" } }
+{ "index" : { "_index": "receipts", "_id" : "recHash2" } }
 {"value":"","sender":"sender2","txHash":"txHash2","timestamp":0}
 `
-	require.Equal(t, expectedRes, res[0].String())
+	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
 }
 
 func TestSerializeTransactionsIntraShardTx(t *testing.T) {
 	t.Parallel()
 
-	buffers, err := (&txsDatabaseProcessor{}).SerializeTransactions([]*data.Transaction{{
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := (&txsDatabaseProcessor{}).SerializeTransactions([]*data.Transaction{{
 		Hash:                 "txHash",
 		SmartContractResults: []*data.ScResult{{}},
-	}}, map[string]string{}, 0)
+	}}, map[string]string{}, 0, buffSlice, "transactions")
 	require.Nil(t, err)
 
-	expectedBuff := `{ "index" : { "_id" : "txHash", "_type" : "_doc" } }
+	expectedBuff := `{ "index" : { "_index":"transactions", "_id" : "txHash", "_type" : "_doc" } }
 {"miniBlockHash":"","nonce":0,"round":0,"value":"","receiver":"","sender":"","receiverShard":0,"senderShard":0,"gasPrice":0,"gasLimit":0,"gasUsed":0,"fee":"","data":null,"signature":"","timestamp":0,"status":"","searchOrder":0}
 `
-	require.Equal(t, expectedBuff, buffers[0].String())
+	require.Equal(t, expectedBuff, buffSlice.Buffers()[0].String())
 }
 
 func TestSerializeTransactionCrossShardTxSource(t *testing.T) {
 	t.Parallel()
 
-	buffers, err := (&txsDatabaseProcessor{}).SerializeTransactions([]*data.Transaction{{
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := (&txsDatabaseProcessor{}).SerializeTransactions([]*data.Transaction{{
 		Hash:                 "txHash",
 		SenderShard:          0,
 		ReceiverShard:        1,
 		SmartContractResults: []*data.ScResult{{}},
 		Version:              1,
-	}}, map[string]string{}, 0)
+	}}, map[string]string{}, 0, buffSlice, "transactions")
 	require.Nil(t, err)
 
-	expectedBuff := `{"update":{"_id":"txHash", "_type": "_doc"}}
+	expectedBuff := `{"update":{ "_index":"transactions", "_id":"txHash", "_type": "_doc"}}
 {"script":{"source":"return"},"upsert":{"miniBlockHash":"","nonce":0,"round":0,"value":"","receiver":"","sender":"","receiverShard":1,"senderShard":0,"gasPrice":0,"gasLimit":0,"gasUsed":0,"fee":"","data":null,"signature":"","timestamp":0,"status":"","searchOrder":0,"version":1}}
 `
-	require.Equal(t, expectedBuff, buffers[0].String())
+	require.Equal(t, expectedBuff, buffSlice.Buffers()[0].String())
 }
 
 func TestSerializeTransactionsCrossShardTxDestination(t *testing.T) {
 	t.Parallel()
 
-	buffers, err := (&txsDatabaseProcessor{}).SerializeTransactions([]*data.Transaction{{
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := (&txsDatabaseProcessor{}).SerializeTransactions([]*data.Transaction{{
 		Hash:                 "txHash",
 		SenderShard:          1,
 		ReceiverShard:        0,
 		SmartContractResults: []*data.ScResult{{}},
 		Version:              1,
-	}}, map[string]string{}, 0)
+	}}, map[string]string{}, 0, buffSlice, "transactions")
 	require.Nil(t, err)
 
-	expectedBuff := `{ "index" : { "_id" : "txHash", "_type" : "_doc" } }
+	expectedBuff := `{ "index" : { "_index":"transactions", "_id" : "txHash", "_type" : "_doc" } }
 {"miniBlockHash":"","nonce":0,"round":0,"value":"","receiver":"","sender":"","receiverShard":0,"senderShard":1,"gasPrice":0,"gasLimit":0,"gasUsed":0,"fee":"","data":null,"signature":"","timestamp":0,"status":"","searchOrder":0,"version":1}
 `
-	require.Equal(t, expectedBuff, buffers[0].String())
+	require.Equal(t, expectedBuff, buffSlice.Buffers()[0].String())
 }
 
 func TestTxsDatabaseProcessor_SerializeTransactionWithRefund(t *testing.T) {
@@ -137,13 +142,15 @@ func TestTxsDatabaseProcessor_SerializeTransactionWithRefund(t *testing.T) {
 			Receiver: "sender",
 		},
 	}
-	buffers, err := (&txsDatabaseProcessor{
+
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
+	err := (&txsDatabaseProcessor{
 		txFeeCalculator: &mock.EconomicsHandlerMock{},
-	}).SerializeTransactionWithRefund(txs, txHashRefund)
+	}).SerializeTransactionWithRefund(txs, txHashRefund, buffSlice, "transactions")
 	require.Nil(t, err)
 
-	expectedBuff := `{ "index" : { "_id" : "txHash" } }
+	expectedBuff := `{ "index" : { "_index": "transactions", "_id" : "txHash" } }
 {"miniBlockHash":"","nonce":0,"round":0,"value":"","receiver":"receiver","sender":"sender","receiverShard":0,"senderShard":0,"gasPrice":1000000000,"gasLimit":150000000,"gasUsed":139832352,"fee":"1447823520000000","data":null,"signature":"","timestamp":0,"status":"","searchOrder":0}
 `
-	require.Equal(t, expectedBuff, buffers[0].String())
+	require.Equal(t, expectedBuff, buffSlice.Buffers()[0].String())
 }

--- a/process/validators/serialize.go
+++ b/process/validators/serialize.go
@@ -31,7 +31,7 @@ func (vp *validatorsProcessor) SerializeValidatorsRating(
 	index string,
 	validatorsRatingInfo []*data.ValidatorRatingInfo,
 ) ([]*bytes.Buffer, error) {
-	buffSlice := data.NewBufferSlice()
+	buffSlice := data.NewBufferSlice(data.BulkSizeThreshold)
 
 	// inside elrond-go, the index is "shardID_epoch" so in order to keep backwards compatibility some adjustments have to be made.
 	// shardID from index name has to be removed because it is sufficient to have document id = blsKey_epoch


### PR DESCRIPTION
- Refactor `elasticsearch` processor in order to optimize the number of request that are did by the indexer. 
- Instead of doing a request for every index data now is done a big bulk request with all the data.