### PR TITLE
do not insert in accounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,6 @@ start-cluster-with-kibana:
 
 stop-cluster:
 	docker-compose down
+
+delete-cluster-data:
+	cd scripts && ./script.sh delete

--- a/converters/tokenMetaData.go
+++ b/converters/tokenMetaData.go
@@ -83,7 +83,7 @@ func PrepareNFTUpdateData(buffSlice *data.BufferSlice, updateNFTData []*data.NFT
 			id = fmt.Sprintf("%s-%s", nftUpdate.Address, nftUpdate.Identifier)
 		}
 
-		metaData := []byte(fmt.Sprintf(`{"update":{ "_index":"%s","_id":"%s", "_type": "_doc"}}%s`, index, id, "\n"))
+		metaData := []byte(fmt.Sprintf(`{"update":{ "_index":"%s","_id":"%s"}}%s`, index, id, "\n"))
 		base64Attr := base64.StdEncoding.EncodeToString(nftUpdate.NewAttributes)
 		serializedData := []byte(fmt.Sprintf(`{"script": {"source": "if (ctx._source.containsKey('data')) {ctx._source.data.attributes = params.attributes}","lang": "painless","params": {"attributes": "%s"}}, "upsert": {}}`, base64Attr))
 		if len(nftUpdate.URIsToAdd) != 0 {

--- a/converters/tokenMetaData_test.go
+++ b/converters/tokenMetaData_test.go
@@ -60,9 +60,9 @@ func TestPrepareNFTUpdateData(t *testing.T) {
 	}
 	err := PrepareNFTUpdateData(buffSlice, nftUpdateData, false, "tokens")
 	require.Nil(t, err)
-	require.Equal(t, `{"update":{ "_index":"tokens","_id":"MYTKN-abcd-01", "_type": "_doc"}}
+	require.Equal(t, `{"update":{ "_index":"tokens","_id":"MYTKN-abcd-01"}}
 {"script": {"source": "if (ctx._source.containsKey('data')) {ctx._source.data.attributes = params.attributes}","lang": "painless","params": {"attributes": "YWFhYQ=="}}, "upsert": {}}
-{"update":{ "_index":"tokens","_id":"TOKEN-1234-1a", "_type": "_doc"}}
+{"update":{ "_index":"tokens","_id":"TOKEN-1234-1a"}}
 {"script": {"source": "if (ctx._source.containsKey('data')) { if (!ctx._source.data.containsKey('uris')) { ctx._source.data.uris = params.uris; } else {  ctx._source.data.uris.addAll(params.uris); }}","lang": "painless","params": {"uris": ["dXJpMQ==","dXJpMg=="]}},"upsert": {}}
 `, buffSlice.Buffers()[0].String())
 }

--- a/integrationtests/accountsBalanceWithLowerTimestamp_test.go
+++ b/integrationtests/accountsBalanceWithLowerTimestamp_test.go
@@ -1,0 +1,219 @@
+//go:build integrationtests
+
+package integrationtests
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	indexerdata "github.com/ElrondNetwork/elastic-indexer-go"
+	"github.com/ElrondNetwork/elastic-indexer-go/mock"
+	"github.com/ElrondNetwork/elrond-go-core/core"
+	coreData "github.com/ElrondNetwork/elrond-go-core/data"
+	dataBlock "github.com/ElrondNetwork/elrond-go-core/data/block"
+	"github.com/ElrondNetwork/elrond-go-core/data/esdt"
+	"github.com/ElrondNetwork/elrond-go-core/data/indexer"
+	"github.com/ElrondNetwork/elrond-go-core/data/transaction"
+	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIndexAccountsBalance(t *testing.T) {
+	setLogLevelDebug()
+
+	esClient, err := createESClient(esURL)
+	require.Nil(t, err)
+
+	accounts := &mock.AccountsStub{}
+	feeComputer := &mock.EconomicsHandlerMock{}
+
+	// ################ UPDATE ACCOUNT-ESDT BALANCE ##########################
+	shardCoordinator := &mock.ShardCoordinatorMock{
+		SelfID: 0,
+	}
+
+	body := &dataBlock.Body{}
+
+	esdtToken := &esdt.ESDigitalToken{
+		Value: big.NewInt(1000),
+	}
+
+	addr := "aaaabbbb"
+	mockAccount := &mock.UserAccountStub{
+		RetrieveValueFromDataTrieTrackerCalled: func(key []byte) ([]byte, error) {
+			return json.Marshal(esdtToken)
+		},
+		AddressBytesCalled: func() []byte {
+			return []byte(addr)
+		},
+	}
+	accounts = &mock.AccountsStub{
+		LoadAccountCalled: func(container []byte) (vmcommon.AccountHandler, error) {
+			return mockAccount, nil
+		},
+	}
+	esProc, err := CreateElasticProcessor(esClient, accounts, shardCoordinator, feeComputer)
+	require.Nil(t, err)
+
+	header := &dataBlock.Header{
+		Round:     51,
+		TimeStamp: 5600,
+	}
+
+	pool := &indexer.Pool{
+		Logs: []*coreData.LogData{
+			{
+				TxHash: "h1",
+				LogHandler: &transaction.Log{
+					Events: []*transaction.Event{
+						{
+							Address:    []byte("eeeebbbb"),
+							Identifier: []byte(core.BuiltInFunctionESDTTransfer),
+							Topics:     [][]byte{[]byte("TTTT-abcd"), nil, big.NewInt(1).Bytes()},
+						},
+						nil,
+					},
+				},
+			},
+		},
+	}
+
+	err = esProc.SaveTransactions(body, header, pool)
+	require.Nil(t, err)
+
+	ids := []string{"6161616162626262"}
+	genericResponse := &GenericResponse{}
+	err = esClient.DoMultiGet(ids, indexerdata.AccountsIndex, true, genericResponse)
+	require.Nil(t, err)
+	require.JSONEq(t, readExpectedResult("./testdata/accountsBalanceWithLowerTimestamp/account-balance-first-update.json"), string(genericResponse.Docs[0].Source))
+
+	ids = []string{"6161616162626262-TTTT-abcd-00"}
+	genericResponse = &GenericResponse{}
+	err = esClient.DoMultiGet(ids, indexerdata.AccountsESDTIndex, true, genericResponse)
+	require.Nil(t, err)
+	require.JSONEq(t, readExpectedResult("./testdata/accountsBalanceWithLowerTimestamp/account-balance-esdt-first-update.json"), string(genericResponse.Docs[0].Source))
+
+	//////////////////// INDEX BALANCE LOWER TIMESTAMP ///////////////////////////////////
+
+	header = &dataBlock.Header{
+		Round:     51,
+		TimeStamp: 5000,
+	}
+	mockAccount.GetBalanceCalled = func() *big.Int {
+		return big.NewInt(1000)
+	}
+
+	err = esProc.SaveTransactions(body, header, pool)
+	require.Nil(t, err)
+
+	ids = []string{"6161616162626262"}
+	genericResponse = &GenericResponse{}
+	err = esClient.DoMultiGet(ids, indexerdata.AccountsIndex, true, genericResponse)
+	require.Nil(t, err)
+	require.JSONEq(t, readExpectedResult("./testdata/accountsBalanceWithLowerTimestamp/account-balance-first-update.json"), string(genericResponse.Docs[0].Source))
+
+	ids = []string{"6161616162626262-TTTT-abcd-00"}
+	genericResponse = &GenericResponse{}
+	err = esClient.DoMultiGet(ids, indexerdata.AccountsESDTIndex, true, genericResponse)
+	require.Nil(t, err)
+	require.JSONEq(t, readExpectedResult("./testdata/accountsBalanceWithLowerTimestamp/account-balance-esdt-first-update.json"), string(genericResponse.Docs[0].Source))
+
+	//////////////////// INDEX BALANCE HIGHER TIMESTAMP ///////////////////////////////////
+	header = &dataBlock.Header{
+		Round:     51,
+		TimeStamp: 6000,
+	}
+	mockAccount.GetBalanceCalled = func() *big.Int {
+		return big.NewInt(2000)
+	}
+
+	pool = &indexer.Pool{
+		Txs: map[string]coreData.TransactionHandler{
+			"h1": &transaction.Transaction{
+				SndAddr: []byte("eeeebbbb"),
+			},
+		},
+		Logs: []*coreData.LogData{
+			{
+				TxHash: "h1",
+				LogHandler: &transaction.Log{
+					Events: []*transaction.Event{
+						{
+							Address:    []byte("eeeebbbb"),
+							Identifier: []byte(core.BuiltInFunctionESDTTransfer),
+							Topics:     [][]byte{[]byte("TTTT-abcd"), nil, big.NewInt(1).Bytes()},
+						},
+						nil,
+					},
+				},
+			},
+		},
+	}
+	body = &dataBlock.Body{
+		MiniBlocks: []*dataBlock.MiniBlock{
+			{
+				Type:     dataBlock.TxBlock,
+				TxHashes: [][]byte{[]byte("h1")},
+			},
+		},
+	}
+
+	err = esProc.SaveTransactions(body, header, pool)
+	require.Nil(t, err)
+
+	ids = []string{"6161616162626262"}
+	genericResponse = &GenericResponse{}
+	err = esClient.DoMultiGet(ids, indexerdata.AccountsIndex, true, genericResponse)
+	require.Nil(t, err)
+	require.JSONEq(t, readExpectedResult("./testdata/accountsBalanceWithLowerTimestamp/account-balance-second-update.json"), string(genericResponse.Docs[0].Source))
+
+	ids = []string{"6161616162626262-TTTT-abcd-00"}
+	genericResponse = &GenericResponse{}
+	err = esClient.DoMultiGet(ids, indexerdata.AccountsESDTIndex, true, genericResponse)
+	require.Nil(t, err)
+	require.JSONEq(t, readExpectedResult("./testdata/accountsBalanceWithLowerTimestamp/account-balance-esdt-second-update.json"), string(genericResponse.Docs[0].Source))
+
+	//////////////////////// DELETE ESDT BALANCE LOWER TIMESTAMP ////////////////
+
+	esdtToken.Value = big.NewInt(0)
+	mockAccount = &mock.UserAccountStub{
+		RetrieveValueFromDataTrieTrackerCalled: func(key []byte) ([]byte, error) {
+			return json.Marshal(esdtToken)
+		},
+		AddressBytesCalled: func() []byte {
+			return []byte(addr)
+		},
+	}
+	accounts = &mock.AccountsStub{
+		LoadAccountCalled: func(container []byte) (vmcommon.AccountHandler, error) {
+			return mockAccount, nil
+		},
+	}
+	esProc, err = CreateElasticProcessor(esClient, accounts, shardCoordinator, feeComputer)
+	require.Nil(t, err)
+
+	header = &dataBlock.Header{
+		Round:     51,
+		TimeStamp: 6001,
+	}
+	mockAccount.GetBalanceCalled = func() *big.Int {
+		return big.NewInt(2000)
+	}
+
+	pool.Txs = make(map[string]coreData.TransactionHandler)
+	err = esProc.SaveTransactions(body, header, pool)
+	require.Nil(t, err)
+
+	ids = []string{"6161616162626262"}
+	genericResponse = &GenericResponse{}
+	err = esClient.DoMultiGet(ids, indexerdata.AccountsIndex, true, genericResponse)
+	require.Nil(t, err)
+	require.JSONEq(t, readExpectedResult("./testdata/accountsBalanceWithLowerTimestamp/account-balance-second-update.json"), string(genericResponse.Docs[0].Source))
+
+	ids = []string{"6161616162626262-TTTT-abcd-00"}
+	genericResponse = &GenericResponse{}
+	err = esClient.DoMultiGet(ids, indexerdata.AccountsESDTIndex, true, genericResponse)
+	require.Nil(t, err)
+	require.False(t, genericResponse.Docs[0].Found)
+}

--- a/integrationtests/testdata/accountsBalanceWithLowerTimestamp/account-balance-esdt-first-update.json
+++ b/integrationtests/testdata/accountsBalanceWithLowerTimestamp/account-balance-esdt-first-update.json
@@ -1,0 +1,8 @@
+{
+  "address": "6161616162626262",
+  "balance": "1000",
+  "balanceNum": 1e-15,
+  "token": "TTTT-abcd",
+  "timestamp": 5600,
+  "type": "FungibleESDT"
+}

--- a/integrationtests/testdata/accountsBalanceWithLowerTimestamp/account-balance-esdt-second-update.json
+++ b/integrationtests/testdata/accountsBalanceWithLowerTimestamp/account-balance-esdt-second-update.json
@@ -1,0 +1,8 @@
+{
+  "address": "6161616162626262",
+  "balance": "1000",
+  "balanceNum": 1e-15,
+  "timestamp": 6000,
+  "token": "TTTT-abcd",
+  "type": "FungibleESDT"
+}

--- a/integrationtests/testdata/accountsBalanceWithLowerTimestamp/account-balance-first-update.json
+++ b/integrationtests/testdata/accountsBalanceWithLowerTimestamp/account-balance-first-update.json
@@ -1,0 +1,7 @@
+{
+  "address": "6161616162626262",
+  "balance": "0",
+  "balanceNum": 0,
+  "totalBalanceWithStake": "0",
+  "timestamp": 5600
+}

--- a/integrationtests/testdata/accountsBalanceWithLowerTimestamp/account-balance-second-update.json
+++ b/integrationtests/testdata/accountsBalanceWithLowerTimestamp/account-balance-second-update.json
@@ -1,0 +1,7 @@
+{
+  "address": "6161616162626262",
+  "balance": "2000",
+  "balanceNum": 0,
+  "timestamp": 6000,
+  "totalBalanceWithStake": "2000"
+}

--- a/integrationtests/utils.go
+++ b/integrationtests/utils.go
@@ -2,6 +2,8 @@ package integrationtests
 
 import (
 	"encoding/json"
+	"io/ioutil"
+	"os"
 	"testing"
 
 	indexer "github.com/ElrondNetwork/elastic-indexer-go"
@@ -63,4 +65,11 @@ func compareTxs(t *testing.T, expected []byte, actual []byte) {
 	require.Nil(t, err)
 
 	require.Equal(t, expectedTx, actualTx)
+}
+
+func readExpectedResult(path string) string {
+	jsonFile, _ := os.Open(path)
+	byteValue, _ := ioutil.ReadAll(jsonFile)
+
+	return string(byteValue)
 }

--- a/process/accounts/accountsProcessor.go
+++ b/process/accounts/accountsProcessor.go
@@ -148,11 +148,11 @@ func (ap *accountsProcessor) PrepareRegularAccountsMap(timestamp uint64, account
 		acc := &data.AccountInfo{
 			Address:                  address,
 			Nonce:                    userAccount.UserAccount.GetNonce(),
-			Balance:                  balance.String(),
+			Balance:                  converters.BigIntToString(balance),
 			BalanceNum:               balanceAsFloat,
 			IsSender:                 userAccount.IsSender,
 			IsSmartContract:          core.IsSmartContractAddress(userAccount.UserAccount.AddressBytes()),
-			TotalBalanceWithStake:    balance.String(),
+			TotalBalanceWithStake:    converters.BigIntToString(balance),
 			TotalBalanceWithStakeNum: balanceAsFloat,
 			Timestamp:                time.Duration(timestamp),
 		}

--- a/process/accounts/serialize.go
+++ b/process/accounts/serialize.go
@@ -86,7 +86,7 @@ func prepareDeleteAccountInfo(acct *data.AccountInfo, isESDT bool, index string)
 		id += fmt.Sprintf("-%s-%s", acct.TokenName, hexEncodedNonce)
 	}
 
-	meta := []byte(fmt.Sprintf(`{ "update" : {"_index":"%s", "_id" : "%s", "_type" : "_doc" } }%s`, index, id, "\n"))
+	meta := []byte(fmt.Sprintf(`{ "update" : {"_index":"%s", "_id" : "%s" } }%s`, index, id, "\n"))
 
 	serializedDataStr := fmt.Sprintf(`{"scripted_upsert": true, "script": {`+
 		`"source": "if ( ctx.op == 'create' )  { ctx.op = 'noop' } else { if (ctx._source.timestamp < params.timestamp ) { ctx.op = 'delete'  } }",`+
@@ -115,7 +115,7 @@ func prepareSerializedAccountInfo(
 		return nil, nil, err
 	}
 
-	meta := []byte(fmt.Sprintf(`{ "update" : {"_index": "%s", "_id" : "%s", "_type" : "_doc" } }%s`, index, id, "\n"))
+	meta := []byte(fmt.Sprintf(`{ "update" : {"_index": "%s", "_id" : "%s" } }%s`, index, id, "\n"))
 	serializedDataStr := fmt.Sprintf(`{"scripted_upsert": true, "script": {`+
 		`"source": "if ( ctx.op == 'create' )  { ctx._source = params.account } else { if (ctx._source.timestamp < params.account.timestamp ) { ctx._source = params.account  } }",`+
 		`"lang": "painless",`+
@@ -181,7 +181,7 @@ func (ap *accountsProcessor) SerializeTypeForProvidedIDs(
 	index string,
 ) error {
 	for _, id := range ids {
-		meta := []byte(fmt.Sprintf(`{ "update" : {"_index":"%s", "_id" : "%s", "_type" : "_doc" } }%s`, index, id, "\n"))
+		meta := []byte(fmt.Sprintf(`{ "update" : {"_index":"%s", "_id" : "%s" } }%s`, index, id, "\n"))
 
 		serializedDataStr := fmt.Sprintf(`{"scripted_upsert": true, "script": {`+
 			`"source": "if ( ctx.op == 'create' )  { ctx.op = 'noop' } else  { ctx._source.type = params.type }",`+

--- a/process/accounts/serialize.go
+++ b/process/accounts/serialize.go
@@ -72,23 +72,31 @@ func (ap *accountsProcessor) SerializeAccountsESDT(
 
 func prepareSerializedAccount(acc *data.AccountInfo, isESDT bool, index string) ([]byte, []byte, error) {
 	if (acc.Balance == "0" || acc.Balance == "") && isESDT {
-		meta := prepareDeleteAccountInfo(acc, isESDT, index)
-		return meta, nil, nil
+		meta, serializedData := prepareDeleteAccountInfo(acc, isESDT, index)
+		return meta, serializedData, nil
 	}
 
 	return prepareSerializedAccountInfo(acc, isESDT, index)
 }
 
-func prepareDeleteAccountInfo(acct *data.AccountInfo, isESDT bool, index string) []byte {
+func prepareDeleteAccountInfo(acct *data.AccountInfo, isESDT bool, index string) ([]byte, []byte) {
 	id := acct.Address
 	if isESDT {
 		hexEncodedNonce := converters.EncodeNonceToHex(acct.TokenNonce)
 		id += fmt.Sprintf("-%s-%s", acct.TokenName, hexEncodedNonce)
 	}
 
-	meta := []byte(fmt.Sprintf(`{ "delete" : {"_index":"%s", "_id" : "%s" } }%s`, index, id, "\n"))
+	meta := []byte(fmt.Sprintf(`{ "update" : {"_index":"%s", "_id" : "%s", "_type" : "_doc" } }%s`, index, id, "\n"))
 
-	return meta
+	serializedDataStr := fmt.Sprintf(`{"scripted_upsert": true, "script": {`+
+		`"source": "if ( ctx.op == 'create' )  { ctx.op = 'noop' } else { if (ctx._source.timestamp < params.timestamp ) { ctx.op = 'delete'  } }",`+
+		`"lang": "painless",`+
+		`"params": {"timestamp": %d}},`+
+		`"upsert": {}}`,
+		acct.Timestamp,
+	)
+
+	return meta, []byte(serializedDataStr)
 }
 
 func prepareSerializedAccountInfo(
@@ -102,13 +110,21 @@ func prepareSerializedAccountInfo(
 		id += fmt.Sprintf("-%s-%s", account.TokenName, hexEncodedNonce)
 	}
 
-	meta := []byte(fmt.Sprintf(`{ "index" : { "_index":"%s", "_id" : "%s" } }%s`, index, id, "\n"))
-	serializedData, err := json.Marshal(account)
+	serializedAccount, err := json.Marshal(account)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return meta, serializedData, nil
+	meta := []byte(fmt.Sprintf(`{ "update" : {"_index": "%s", "_id" : "%s", "_type" : "_doc" } }%s`, index, id, "\n"))
+	serializedDataStr := fmt.Sprintf(`{"scripted_upsert": true, "script": {`+
+		`"source": "if ( ctx.op == 'create' )  { ctx._source = params.account } else { if (ctx._source.timestamp < params.account.timestamp ) { ctx._source = params.account  } }",`+
+		`"lang": "painless",`+
+		`"params": { "account": %s }},`+
+		`"upsert": {}}`,
+		serializedAccount,
+	)
+
+	return meta, []byte(serializedDataStr), nil
 }
 
 // SerializeAccountsHistory will serialize accounts history in a way that Elastic Search expects a bulk request

--- a/process/accounts/serialize_test.go
+++ b/process/accounts/serialize_test.go
@@ -55,8 +55,8 @@ func TestSerializeAccounts(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(buffSlice.Buffers()))
 
-	expectedRes := `{ "index" : { "_index":"accounts", "_id" : "addr1" } }
-{"address":"addr1","nonce":1,"balance":"50","balanceNum":0.1,"totalBalanceWithStake":"50","totalBalanceWithStakeNum":0.1}
+	expectedRes := `{ "update" : {"_index": "accounts", "_id" : "addr1", "_type" : "_doc" } }
+{"scripted_upsert": true, "script": {"source": "if ( ctx.op == 'create' )  { ctx._source = params.account } else { if (ctx._source.timestamp < params.account.timestamp ) { ctx._source = params.account  } }","lang": "painless","params": { "account": {"address":"addr1","nonce":1,"balance":"50","balanceNum":0.1,"totalBalanceWithStake":"50","totalBalanceWithStakeNum":0.1} }},"upsert": {}}
 `
 	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
 }
@@ -82,8 +82,8 @@ func TestSerializeAccountsESDTNonceZero(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(buffSlice.Buffers()))
 
-	expectedRes := `{ "index" : { "_index":"accountsesdt", "_id" : "addr1-token-abcd-00" } }
-{"address":"addr1","nonce":1,"balance":"10000000000000","balanceNum":1,"token":"token-abcd","properties":"000","timestamp":123}
+	expectedRes := `{ "update" : {"_index": "accountsesdt", "_id" : "addr1-token-abcd-00", "_type" : "_doc" } }
+{"scripted_upsert": true, "script": {"source": "if ( ctx.op == 'create' )  { ctx._source = params.account } else { if (ctx._source.timestamp < params.account.timestamp ) { ctx._source = params.account  } }","lang": "painless","params": { "account": {"address":"addr1","nonce":1,"balance":"10000000000000","balanceNum":1,"token":"token-abcd","properties":"000","timestamp":123} }},"upsert": {}}
 `
 	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
 }
@@ -108,8 +108,8 @@ func TestSerializeAccountsESDT(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(buffSlice.Buffers()))
 
-	expectedRes := `{ "index" : { "_index":"accountsesdt", "_id" : "addr1-token-0001-05" } }
-{"address":"addr1","nonce":1,"balance":"10000000000000","balanceNum":1,"token":"token-0001","tokenNonce":5,"properties":"000"}
+	expectedRes := `{ "update" : {"_index": "accountsesdt", "_id" : "addr1-token-0001-05", "_type" : "_doc" } }
+{"scripted_upsert": true, "script": {"source": "if ( ctx.op == 'create' )  { ctx._source = params.account } else { if (ctx._source.timestamp < params.account.timestamp ) { ctx._source = params.account  } }","lang": "painless","params": { "account": {"address":"addr1","nonce":1,"balance":"10000000000000","balanceNum":1,"token":"token-0001","tokenNonce":5,"properties":"000"} }},"upsert": {}}
 `
 	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
 }
@@ -148,8 +148,8 @@ func TestSerializeAccountsNFTWithMedaData(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(buffSlice.Buffers()))
 
-	expectedRes := `{ "index" : { "_index":"accountsesdt", "_id" : "addr1-token-0001-16" } }
-{"address":"addr1","nonce":1,"balance":"10000000000000","balanceNum":1,"token":"token-0001","identifier":"token-0001-5","tokenNonce":22,"properties":"000","data":{"name":"nft","creator":"010101","royalties":1,"hash":"aGFzaA==","uris":["dXJp"],"tags":["test","free","fun"],"attributes":"dGFnczp0ZXN0LGZyZWUsZnVuO2Rlc2NyaXB0aW9uOlRoaXMgaXMgYSB0ZXN0IGRlc2NyaXB0aW9uIGZvciBhbiBhd2Vzb21lIG5mdA==","metadata":"metadata-test","nonEmptyURIs":true,"whiteListedStorage":false}}
+	expectedRes := `{ "update" : {"_index": "accountsesdt", "_id" : "addr1-token-0001-16", "_type" : "_doc" } }
+{"scripted_upsert": true, "script": {"source": "if ( ctx.op == 'create' )  { ctx._source = params.account } else { if (ctx._source.timestamp < params.account.timestamp ) { ctx._source = params.account  } }","lang": "painless","params": { "account": {"address":"addr1","nonce":1,"balance":"10000000000000","balanceNum":1,"token":"token-0001","identifier":"token-0001-5","tokenNonce":22,"properties":"000","data":{"name":"nft","creator":"010101","royalties":1,"hash":"aGFzaA==","uris":["dXJp"],"tags":["test","free","fun"],"attributes":"dGFnczp0ZXN0LGZyZWUsZnVuO2Rlc2NyaXB0aW9uOlRoaXMgaXMgYSB0ZXN0IGRlc2NyaXB0aW9uIGZvciBhbiBhd2Vzb21lIG5mdA==","metadata":"metadata-test","nonEmptyURIs":true,"whiteListedStorage":false}} }},"upsert": {}}
 `
 	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
 }
@@ -173,7 +173,8 @@ func TestSerializeAccountsESDTDelete(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(buffSlice.Buffers()))
 
-	expectedRes := `{ "delete" : {"_index":"accountsesdt", "_id" : "addr1-token-0001-00" } }
+	expectedRes := `{ "update" : {"_index":"accountsesdt", "_id" : "addr1-token-0001-00", "_type" : "_doc" } }
+{"scripted_upsert": true, "script": {"source": "if ( ctx.op == 'create' )  { ctx.op = 'noop' } else { if (ctx._source.timestamp < params.timestamp ) { ctx.op = 'delete'  } }","lang": "painless","params": {"timestamp": 0}},"upsert": {}}
 `
 	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
 }

--- a/process/accounts/serialize_test.go
+++ b/process/accounts/serialize_test.go
@@ -55,7 +55,7 @@ func TestSerializeAccounts(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(buffSlice.Buffers()))
 
-	expectedRes := `{ "update" : {"_index": "accounts", "_id" : "addr1", "_type" : "_doc" } }
+	expectedRes := `{ "update" : {"_index": "accounts", "_id" : "addr1" } }
 {"scripted_upsert": true, "script": {"source": "if ( ctx.op == 'create' )  { ctx._source = params.account } else { if (ctx._source.timestamp < params.account.timestamp ) { ctx._source = params.account  } }","lang": "painless","params": { "account": {"address":"addr1","nonce":1,"balance":"50","balanceNum":0.1,"totalBalanceWithStake":"50","totalBalanceWithStakeNum":0.1} }},"upsert": {}}
 `
 	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
@@ -82,7 +82,7 @@ func TestSerializeAccountsESDTNonceZero(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(buffSlice.Buffers()))
 
-	expectedRes := `{ "update" : {"_index": "accountsesdt", "_id" : "addr1-token-abcd-00", "_type" : "_doc" } }
+	expectedRes := `{ "update" : {"_index": "accountsesdt", "_id" : "addr1-token-abcd-00" } }
 {"scripted_upsert": true, "script": {"source": "if ( ctx.op == 'create' )  { ctx._source = params.account } else { if (ctx._source.timestamp < params.account.timestamp ) { ctx._source = params.account  } }","lang": "painless","params": { "account": {"address":"addr1","nonce":1,"balance":"10000000000000","balanceNum":1,"token":"token-abcd","properties":"000","timestamp":123} }},"upsert": {}}
 `
 	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
@@ -108,7 +108,7 @@ func TestSerializeAccountsESDT(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(buffSlice.Buffers()))
 
-	expectedRes := `{ "update" : {"_index": "accountsesdt", "_id" : "addr1-token-0001-05", "_type" : "_doc" } }
+	expectedRes := `{ "update" : {"_index": "accountsesdt", "_id" : "addr1-token-0001-05" } }
 {"scripted_upsert": true, "script": {"source": "if ( ctx.op == 'create' )  { ctx._source = params.account } else { if (ctx._source.timestamp < params.account.timestamp ) { ctx._source = params.account  } }","lang": "painless","params": { "account": {"address":"addr1","nonce":1,"balance":"10000000000000","balanceNum":1,"token":"token-0001","tokenNonce":5,"properties":"000"} }},"upsert": {}}
 `
 	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
@@ -148,7 +148,7 @@ func TestSerializeAccountsNFTWithMedaData(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(buffSlice.Buffers()))
 
-	expectedRes := `{ "update" : {"_index": "accountsesdt", "_id" : "addr1-token-0001-16", "_type" : "_doc" } }
+	expectedRes := `{ "update" : {"_index": "accountsesdt", "_id" : "addr1-token-0001-16" } }
 {"scripted_upsert": true, "script": {"source": "if ( ctx.op == 'create' )  { ctx._source = params.account } else { if (ctx._source.timestamp < params.account.timestamp ) { ctx._source = params.account  } }","lang": "painless","params": { "account": {"address":"addr1","nonce":1,"balance":"10000000000000","balanceNum":1,"token":"token-0001","identifier":"token-0001-5","tokenNonce":22,"properties":"000","data":{"name":"nft","creator":"010101","royalties":1,"hash":"aGFzaA==","uris":["dXJp"],"tags":["test","free","fun"],"attributes":"dGFnczp0ZXN0LGZyZWUsZnVuO2Rlc2NyaXB0aW9uOlRoaXMgaXMgYSB0ZXN0IGRlc2NyaXB0aW9uIGZvciBhbiBhd2Vzb21lIG5mdA==","metadata":"metadata-test","nonEmptyURIs":true,"whiteListedStorage":false}} }},"upsert": {}}
 `
 	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
@@ -173,7 +173,7 @@ func TestSerializeAccountsESDTDelete(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(buffSlice.Buffers()))
 
-	expectedRes := `{ "update" : {"_index":"accountsesdt", "_id" : "addr1-token-0001-00", "_type" : "_doc" } }
+	expectedRes := `{ "update" : {"_index":"accountsesdt", "_id" : "addr1-token-0001-00" } }
 {"scripted_upsert": true, "script": {"source": "if ( ctx.op == 'create' )  { ctx.op = 'noop' } else { if (ctx._source.timestamp < params.timestamp ) { ctx.op = 'delete'  } }","lang": "painless","params": {"timestamp": 0}},"upsert": {}}
 `
 	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())

--- a/process/logsevents/serialize.go
+++ b/process/logsevents/serialize.go
@@ -31,7 +31,7 @@ func (logsAndEventsProcessor) SerializeLogs(logs []*data.Logs, buffSlice *data.B
 // SerializeSCDeploys will serialize the provided smart contract deploys in a way that Elastic Search expects a bulk request
 func (logsAndEventsProcessor) SerializeSCDeploys(deploys map[string]*data.ScDeployInfo, buffSlice *data.BufferSlice, index string) error {
 	for scAddr, deployInfo := range deploys {
-		meta := []byte(fmt.Sprintf(`{ "update" : { "_index":"%s", "_id" : "%s", "_type" : "_doc" } }%s`, index, scAddr, "\n"))
+		meta := []byte(fmt.Sprintf(`{ "update" : { "_index":"%s", "_id" : "%s" } }%s`, index, scAddr, "\n"))
 
 		serializedData, err := serializeDeploy(deployInfo)
 		if err != nil {
@@ -96,7 +96,7 @@ func serializeToken(tokenData *data.TokenInfo, index string) ([]byte, []byte, er
 		return serializeTokenTransferOwnership(tokenData, index)
 	}
 
-	meta := []byte(fmt.Sprintf(`{ "update" : { "_index":"%s", "_id" : "%s", "_type" : "_doc" } }%s`, index, tokenData.Token, "\n"))
+	meta := []byte(fmt.Sprintf(`{ "update" : { "_index":"%s", "_id" : "%s" } }%s`, index, tokenData.Token, "\n"))
 	serializedTokenData, err := json.Marshal(tokenData)
 	if err != nil {
 		return nil, nil, err
@@ -113,7 +113,7 @@ func serializeToken(tokenData *data.TokenInfo, index string) ([]byte, []byte, er
 }
 
 func serializeTokenTransferOwnership(tokenData *data.TokenInfo, index string) ([]byte, []byte, error) {
-	meta := []byte(fmt.Sprintf(`{ "update" : { "_index":"%s", "_id" : "%s", "_type" : "_doc" } }%s`, index, tokenData.Token, "\n"))
+	meta := []byte(fmt.Sprintf(`{ "update" : { "_index":"%s", "_id" : "%s" } }%s`, index, tokenData.Token, "\n"))
 	tokenDataSerialized, err := json.Marshal(tokenData)
 	if err != nil {
 		return nil, nil, err
@@ -212,7 +212,7 @@ func (lep *logsAndEventsProcessor) SerializeRolesData(rolesData data.RolesData, 
 }
 
 func serializeRoleData(buffSlice *data.BufferSlice, rd *data.RoleData, role string, index string) error {
-	meta := []byte(fmt.Sprintf(`{ "update" : {"_index": "%s", "_id" : "%s", "_type" : "_doc" } }%s`, index, rd.Token, "\n"))
+	meta := []byte(fmt.Sprintf(`{ "update" : {"_index": "%s", "_id" : "%s" } }%s`, index, rd.Token, "\n"))
 	var serializedDataStr string
 	if rd.Set {
 		serializedDataStr = fmt.Sprintf(`{"script": {`+

--- a/process/logsevents/serialize_test.go
+++ b/process/logsevents/serialize_test.go
@@ -56,7 +56,7 @@ func TestLogsAndEventsProcessor_SerializeSCDeploys(t *testing.T) {
 	err := (&logsAndEventsProcessor{}).SerializeSCDeploys(scDeploys, buffSlice, "scdeploys")
 	require.Nil(t, err)
 
-	expectedRes := `{ "update" : { "_index":"scdeploys", "_id" : "scAddr", "_type" : "_doc" } }
+	expectedRes := `{ "update" : { "_index":"scdeploys", "_id" : "scAddr" } }
 {"script": {"source": "if (!ctx._source.containsKey('upgrades')) { ctx._source.upgrades = [ params.elem ]; } else {  ctx._source.upgrades.add(params.elem); }","lang": "painless","params": {"elem": {"upgradeTxHash":"hash","upgrader":"creator","timestamp":123}}},"upsert": {"deployTxHash":"hash","deployer":"creator","timestamp":123,"upgrades":[]}}
 `
 	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())
@@ -103,9 +103,9 @@ func TestSerializeTokens(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, 1, len(buffSlice.Buffers()))
 
-	expectedRes := `{ "update" : { "_index":"tokens", "_id" : "TKN-01234", "_type" : "_doc" } }
+	expectedRes := `{ "update" : { "_index":"tokens", "_id" : "TKN-01234" } }
 {"script": {"source": "if (ctx._source.containsKey('roles')) {HashMap roles = ctx._source.roles; ctx._source = params.token; ctx._source.roles = roles}","lang": "painless","params": {"token": {"name":"TokenName","ticker":"TKN","token":"TKN-01234","issuer":"erd123","currentOwner":"erd123","type":"SemiFungibleESDT","timestamp":50000,"ownersHistory":[{"address":"erd123","timestamp":50000}]}}},"upsert": {"name":"TokenName","ticker":"TKN","token":"TKN-01234","issuer":"erd123","currentOwner":"erd123","type":"SemiFungibleESDT","timestamp":50000,"ownersHistory":[{"address":"erd123","timestamp":50000}]}}
-{ "update" : { "_index":"tokens", "_id" : "TKN2-51234", "_type" : "_doc" } }
+{ "update" : { "_index":"tokens", "_id" : "TKN2-51234" } }
 {"script": {"source": "if (!ctx._source.containsKey('ownersHistory')) { ctx._source.ownersHistory = [ params.elem ] } else { ctx._source.ownersHistory.add(params.elem) } ctx._source.currentOwner = params.owner ","lang": "painless","params": {"elem": {"address":"abde123456","timestamp":60000}, "owner": "abde123456"}},"upsert": {"name":"Token2","ticker":"TKN2","token":"TKN2-51234","issuer":"erd1231213123","currentOwner":"abde123456","type":"NonFungibleESDT","timestamp":60000,"ownersHistory":[{"address":"abde123456","timestamp":60000}]}}
 `
 	require.Equal(t, expectedRes, buffSlice.Buffers()[0].String())

--- a/process/operations/serialize.go
+++ b/process/operations/serialize.go
@@ -28,7 +28,7 @@ func (op *operationsProcessor) prepareSerializedDataForAScResult(
 	scr *data.ScResult,
 	index string,
 ) ([]byte, []byte, error) {
-	metaData := []byte(fmt.Sprintf(`{"update":{"_index":"%s","_id":"%s", "_type": "_doc"}}%s`, index, scr.Hash, "\n"))
+	metaData := []byte(fmt.Sprintf(`{"update":{"_index":"%s","_id":"%s"}}%s`, index, scr.Hash, "\n"))
 	marshaledSCR, err := json.Marshal(scr)
 	if err != nil {
 		return nil, nil, err
@@ -44,7 +44,7 @@ func (op *operationsProcessor) prepareSerializedDataForAScResult(
 		return metaData, serializedData, nil
 	}
 
-	meta := []byte(fmt.Sprintf(`{ "index" : { "_index":"%s","_id" : "%s", "_type" : "%s" } }%s`, index, scr.Hash, "_doc", "\n"))
+	meta := []byte(fmt.Sprintf(`{ "index" : { "_index":"%s","_id" : "%s" } }%s`, index, scr.Hash, "\n"))
 
 	return meta, marshaledSCR, nil
 }

--- a/process/operations/serialize_test.go
+++ b/process/operations/serialize_test.go
@@ -27,9 +27,9 @@ func TestOperationsProcessor_SerializeSCRS(t *testing.T) {
 	buffSlice := data.NewBufferSlice(data.DefaultMaxBulkSize)
 	err := op.SerializeSCRs(scrs, buffSlice, "operations")
 	require.Nil(t, err)
-	require.Equal(t, `{"update":{"_index":"operations","_id":"", "_type": "_doc"}}
+	require.Equal(t, `{"update":{"_index":"operations","_id":""}}
 {"script":{"source":"return"},"upsert":{"nonce":0,"gasLimit":0,"gasPrice":0,"value":"","sender":"","receiver":"","senderShard":0,"receiverShard":1,"prevTxHash":"","originalTxHash":"","callType":"","timestamp":0}}
-{ "index" : { "_index":"operations","_id" : "", "_type" : "_doc" } }
+{ "index" : { "_index":"operations","_id" : "" } }
 {"nonce":0,"gasLimit":0,"gasPrice":0,"value":"","sender":"","receiver":"","senderShard":2,"receiverShard":0,"prevTxHash":"","originalTxHash":"","callType":"","timestamp":0}
 `, buffSlice.Buffers()[0].String())
 }

--- a/process/statistics/serialize.go
+++ b/process/statistics/serialize.go
@@ -41,8 +41,7 @@ func (sp *statisticsProcessor) SerializeRoundsInfo(roundsInfo []*data.RoundInfo)
 }
 
 func serializeRoundInfo(info *data.RoundInfo) ([]byte, []byte) {
-	meta := []byte(fmt.Sprintf(`{ "index" : { "_id" : "%d_%d", "_type" : "%s" } }%s`,
-		info.ShardId, info.Index, "_doc", "\n"))
+	meta := []byte(fmt.Sprintf(`{ "index" : { "_id" : "%d_%d" } }%s`, info.ShardId, info.Index, "\n"))
 
 	serializedInfo, err := json.Marshal(info)
 	if err != nil {

--- a/process/statistics/serialize_test.go
+++ b/process/statistics/serialize_test.go
@@ -15,7 +15,7 @@ func TestStatisticsProcessor_SerializeRoundsInfo(t *testing.T) {
 	buff := sp.SerializeRoundsInfo([]*data.RoundInfo{{
 		Epoch: 1,
 	}})
-	expectedBuff := `{ "index" : { "_id" : "0_0", "_type" : "_doc" } }
+	expectedBuff := `{ "index" : { "_id" : "0_0" } }
 {"round":0,"signersIndexes":null,"blockWasProposed":false,"shardId":0,"epoch":1,"timestamp":0}
 `
 	require.Equal(t, expectedBuff, buff.String())

--- a/process/tags/serialize.go
+++ b/process/tags/serialize.go
@@ -15,7 +15,7 @@ func (tc *tagsCount) Serialize(buffSlice *data.BufferSlice, index string) error 
 		}
 
 		base64Tag := base64.StdEncoding.EncodeToString([]byte(tag))
-		meta := []byte(fmt.Sprintf(`{ "update" : {"_index":"%s", "_id" : "%s", "_type" : "_doc" } }%s`, index, base64Tag, "\n"))
+		meta := []byte(fmt.Sprintf(`{ "update" : {"_index":"%s", "_id" : "%s" } }%s`, index, base64Tag, "\n"))
 		serializedDataStr := fmt.Sprintf(`{"script": {"source": "ctx._source.count += params.count","lang": "painless","params": {"count": %d}},"upsert": {"count": %d}}`, count, count)
 
 		err := buffSlice.PutData(meta, []byte(serializedDataStr))

--- a/process/tags/serialize_test.go
+++ b/process/tags/serialize_test.go
@@ -19,7 +19,7 @@ func TestTagsCount_Serialize(t *testing.T) {
 	err := tagsC.Serialize(buffSlice, "tags")
 	require.Nil(t, err)
 
-	expected := `{ "update" : {"_index":"tags", "_id" : "QXJ0", "_type" : "_doc" } }
+	expected := `{ "update" : {"_index":"tags", "_id" : "QXJ0" } }
 {"script": {"source": "ctx._source.count += params.count","lang": "painless","params": {"count": 2}},"upsert": {"count": 2}}
 `
 	require.Equal(t, expected, buffSlice.Buffers()[0].String())

--- a/process/transactions/serialize.go
+++ b/process/transactions/serialize.go
@@ -116,7 +116,7 @@ func (tdp *txsDatabaseProcessor) SerializeTransactions(
 
 func serializeTxHashStatus(buffSlice *data.BufferSlice, txHashStatus map[string]string, index string) error {
 	for txHash, status := range txHashStatus {
-		metaData := []byte(fmt.Sprintf(`{"update":{ "_index":"%s","_id":"%s", "_type": "_doc"}}%s`, index, txHash, "\n"))
+		metaData := []byte(fmt.Sprintf(`{"update":{ "_index":"%s","_id":"%s"}}%s`, index, txHash, "\n"))
 
 		newTx := &data.Transaction{
 			Status: status,
@@ -141,7 +141,7 @@ func prepareSerializedDataForATransaction(
 	selfShardID uint32,
 	index string,
 ) ([]byte, []byte, error) {
-	metaData := []byte(fmt.Sprintf(`{"update":{ "_index":"%s", "_id":"%s", "_type": "_doc"}}%s`, index, tx.Hash, "\n"))
+	metaData := []byte(fmt.Sprintf(`{"update":{ "_index":"%s", "_id":"%s"}}%s`, index, tx.Hash, "\n"))
 	marshaledTx, err := json.Marshal(tx)
 	if err != nil {
 		return nil, nil, err
@@ -167,7 +167,7 @@ func prepareSerializedDataForATransaction(
 	}
 
 	// transaction is intra-shard, invalid or cross-shard destination me
-	meta := []byte(fmt.Sprintf(`{ "index" : { "_index":"%s", "_id" : "%s", "_type" : "%s" } }%s`, index, tx.Hash, "_doc", "\n"))
+	meta := []byte(fmt.Sprintf(`{ "index" : { "_index":"%s", "_id" : "%s" } }%s`, index, tx.Hash, "\n"))
 	log.Trace("indexer tx is intra shard or invalid tx", "meta", string(meta), "marshaledTx", string(marshaledTx))
 
 	return meta, marshaledTx, nil

--- a/process/transactions/serialize_test.go
+++ b/process/transactions/serialize_test.go
@@ -81,7 +81,7 @@ func TestSerializeTransactionsIntraShardTx(t *testing.T) {
 	}}, map[string]string{}, 0, buffSlice, "transactions")
 	require.Nil(t, err)
 
-	expectedBuff := `{ "index" : { "_index":"transactions", "_id" : "txHash", "_type" : "_doc" } }
+	expectedBuff := `{ "index" : { "_index":"transactions", "_id" : "txHash" } }
 {"miniBlockHash":"","nonce":0,"round":0,"value":"","receiver":"","sender":"","receiverShard":0,"senderShard":0,"gasPrice":0,"gasLimit":0,"gasUsed":0,"fee":"","data":null,"signature":"","timestamp":0,"status":"","searchOrder":0}
 `
 	require.Equal(t, expectedBuff, buffSlice.Buffers()[0].String())
@@ -100,7 +100,7 @@ func TestSerializeTransactionCrossShardTxSource(t *testing.T) {
 	}}, map[string]string{}, 0, buffSlice, "transactions")
 	require.Nil(t, err)
 
-	expectedBuff := `{"update":{ "_index":"transactions", "_id":"txHash", "_type": "_doc"}}
+	expectedBuff := `{"update":{ "_index":"transactions", "_id":"txHash"}}
 {"script":{"source":"return"},"upsert":{"miniBlockHash":"","nonce":0,"round":0,"value":"","receiver":"","sender":"","receiverShard":1,"senderShard":0,"gasPrice":0,"gasLimit":0,"gasUsed":0,"fee":"","data":null,"signature":"","timestamp":0,"status":"","searchOrder":0,"version":1}}
 `
 	require.Equal(t, expectedBuff, buffSlice.Buffers()[0].String())
@@ -119,7 +119,7 @@ func TestSerializeTransactionsCrossShardTxDestination(t *testing.T) {
 	}}, map[string]string{}, 0, buffSlice, "transactions")
 	require.Nil(t, err)
 
-	expectedBuff := `{ "index" : { "_index":"transactions", "_id" : "txHash", "_type" : "_doc" } }
+	expectedBuff := `{ "index" : { "_index":"transactions", "_id" : "txHash" } }
 {"miniBlockHash":"","nonce":0,"round":0,"value":"","receiver":"","sender":"","receiverShard":0,"senderShard":1,"gasPrice":0,"gasLimit":0,"gasUsed":0,"fee":"","data":null,"signature":"","timestamp":0,"status":"","searchOrder":0,"version":1}
 `
 	require.Equal(t, expectedBuff, buffSlice.Buffers()[0].String())


### PR DESCRIPTION
- Implement a mechanism that will not insert data in the  `accounts` index and the `accountsesdt` index if the timestamp is lower that the timestamp from database
- Removed also the `_type` field from the requests because is deprecated ( in ES 8.0 will be removed)