### PR TITLE
Delete also scrs at source

### DIFF
--- a/process/transactions/transactionsProcessor.go
+++ b/process/transactions/transactionsProcessor.go
@@ -172,8 +172,9 @@ func (tdp *txsDatabaseProcessor) GetHexEncodedHashesForRemove(header coreData.He
 	encodedTxsHashes := make([]string, 0)
 	encodedScrsHashes := make([]string, 0)
 	for _, miniblock := range body.MiniBlocks {
-		if isCrossShardAtSourceAndNoRewardsMB(selfShardID, miniblock) {
-			// ignore cross-shard miniblocks at source ( exception to this rule are rewards miniblocks)
+		shouldIgnore := isCrossShardAtSourceNormalTx(selfShardID, miniblock)
+		if shouldIgnore {
+			// ignore cross-shard miniblocks at source with normal txs
 			continue
 		}
 
@@ -193,12 +194,12 @@ func (tdp *txsDatabaseProcessor) GetHexEncodedHashesForRemove(header coreData.He
 	return encodedTxsHashes, encodedScrsHashes
 }
 
-func isCrossShardAtSourceAndNoRewardsMB(selfShardID uint32, miniblock *block.MiniBlock) bool {
+func isCrossShardAtSourceNormalTx(selfShardID uint32, miniblock *block.MiniBlock) bool {
 	isCrossShard := miniblock.SenderShardID != miniblock.ReceiverShardID
 	isAtSource := miniblock.SenderShardID == selfShardID
-	noRewardsMb := miniblock.Type != block.RewardsBlock
+	txBlock := miniblock.Type == block.TxBlock
 
-	return isCrossShard && isAtSource && noRewardsMb
+	return isCrossShard && isAtSource && txBlock
 }
 
 func shouldIgnoreProcessedMBScheduled(header coreData.HeaderHandler, mbIndex int) bool {

--- a/process/transactions/transactionsProcessor_test.go
+++ b/process/transactions/transactionsProcessor_test.go
@@ -562,6 +562,14 @@ func TestGetRewardsTxsHashesHexEncoded(t *testing.T) {
 				SenderShardID:   2,
 				ReceiverShardID: core.MetachainShardId,
 			},
+			{
+				TxHashes: [][]byte{
+					[]byte("h7"),
+				},
+				Type:            block.SmartContractResultBlock,
+				SenderShardID:   core.MetachainShardId,
+				ReceiverShardID: 0,
+			},
 		},
 	}
 
@@ -569,7 +577,7 @@ func TestGetRewardsTxsHashesHexEncoded(t *testing.T) {
 		"6831", "6832", "6833", "6835",
 	}
 	expectedScrHashes := []string{
-		"6836",
+		"6836", "6837",
 	}
 
 	txsHashes, scrHashes := txDBProc.GetHexEncodedHashesForRemove(header, body)


### PR DESCRIPTION
- Delete also the smart contract results at the source shard in case of a `RevertBlock` event (this operation is needed because in case of a rollback when the new smart contract results are generated will have a different hash)