### PR TITLE
[BUG_FIX] Smart contract results processor fixes

### DIFF
--- a/process/elasticproc/transactions/smartContractResultsProcessor.go
+++ b/process/elasticproc/transactions/smartContractResultsProcessor.go
@@ -46,8 +46,7 @@ func (proc *smartContractResultsProcessor) processSCRs(
 ) []*indexerData.ScResult {
 	allSCRs := make([]*indexerData.ScResult, 0, len(txsHandler))
 
-	// we need this map because proc.processSCRsFromMiniblock removes items
-	// from the map in order to remain with the smart contract results that have no transaction on the current shard
+	// a copy of the SCRS map is needed because proc.processSCRsFromMiniblock would remove items from the original map
 	workingSCRSMap := copySCRSMap(txsHandler)
 	for _, mb := range body.MiniBlocks {
 		if mb.Type != block.SmartContractResultBlock {


### PR DESCRIPTION
- Fixed the bug related to this WARN `smartContractResultsProcessor.processSCRsFromMiniblock scr not found in map scr hash =.....`
- This problem appears because `smartContractResultsProcessor` removes smart contract results from a map and when it will do a `retry` these elements will be no longer available. 
- In order to fix this situation a copy of the smart contract results map was added and all the removal operations will be done on the new map.