### PR TITLE
added transactions hashes and execution order in block structure

### DIFF
--- a/data/block.go
+++ b/data/block.go
@@ -41,9 +41,15 @@ type Block struct {
 
 // MiniBlocksDetails is a structure that hold information about mini-blocks execution details
 type MiniBlocksDetails struct {
-	IndexFirstProcessedTx int32 `json:"firstProcessedTx"`
-	IndexLastProcessedTx  int32 `json:"lastProcessedTx"`
-	MBIndex               int   `json:"mbIndex"`
+	IndexFirstProcessedTx    int32    `json:"firstProcessedTx"`
+	IndexLastProcessedTx     int32    `json:"lastProcessedTx"`
+	SenderShardID            uint32   `json:"senderShard"`
+	ReceiverShardID          uint32   `json:"receiverShard"`
+	MBIndex                  int      `json:"mbIndex"`
+	Type                     string   `json:"type"`
+	ProcessingType           string   `json:"procType,omitempty"`
+	TxsHashes                []string `json:"txsHashes,omitempty"`
+	ExecutionOrderTxsIndices []int    `json:"executionOrderTxsIndices,omitempty"`
 }
 
 // ScheduledData is a structure that hold information about scheduled events

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ElrondNetwork/elastic-indexer-go
 go 1.17
 
 require (
-	github.com/ElrondNetwork/elrond-go-core v1.1.27-0.20221215101151-0e69a10c3cb5
+	github.com/ElrondNetwork/elrond-go-core v1.1.28
 	github.com/ElrondNetwork/elrond-go-logger v1.0.10
 	github.com/ElrondNetwork/elrond-vm-common v1.3.27
 	github.com/elastic/go-elasticsearch/v7 v7.12.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ElrondNetwork/elastic-indexer-go
 go 1.17
 
 require (
-	github.com/ElrondNetwork/elrond-go-core v1.1.26
+	github.com/ElrondNetwork/elrond-go-core v1.1.27-0.20221215101151-0e69a10c3cb5
 	github.com/ElrondNetwork/elrond-go-logger v1.0.10
 	github.com/ElrondNetwork/elrond-vm-common v1.3.27
 	github.com/elastic/go-elasticsearch/v7 v7.12.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/ElrondNetwork/elrond-go-core v1.1.26/go.mod h1:N/RI++YU2M6OlnD1GSZepc1wPhI84ykRDQ1IyD3B0wk=
-github.com/ElrondNetwork/elrond-go-core v1.1.27-0.20221215101151-0e69a10c3cb5 h1:G3hGxdf54hfAKbY0IeyHs3eITMdbEa0h0csvvjHK2/o=
-github.com/ElrondNetwork/elrond-go-core v1.1.27-0.20221215101151-0e69a10c3cb5/go.mod h1:N/RI++YU2M6OlnD1GSZepc1wPhI84ykRDQ1IyD3B0wk=
+github.com/ElrondNetwork/elrond-go-core v1.1.28 h1:EgDAG2+cWSnekEWkf9WCsRAkh6pQlcQoGCSxzrkOE14=
+github.com/ElrondNetwork/elrond-go-core v1.1.28/go.mod h1:N/RI++YU2M6OlnD1GSZepc1wPhI84ykRDQ1IyD3B0wk=
 github.com/ElrondNetwork/elrond-go-logger v1.0.10 h1:2xQOWZErcHW5sl9qSRO+7mGNw+QhFhqiUlLLtOgvuuk=
 github.com/ElrondNetwork/elrond-go-logger v1.0.10/go.mod h1:+rMODFw4yQptTi5WuLUBzvl/AE26V+2YJtc52wX30Eg=
 github.com/ElrondNetwork/elrond-vm-common v1.3.27 h1:8LYa2ZCPYUXeb7USIWPHUnQnELtSyDKxmSr4QBiAYJg=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/ElrondNetwork/elrond-go-core v1.1.26 h1:5syiJMlkWlH7HHnuiOafJJzeI+oUfYqL8mXREqrFerY=
 github.com/ElrondNetwork/elrond-go-core v1.1.26/go.mod h1:N/RI++YU2M6OlnD1GSZepc1wPhI84ykRDQ1IyD3B0wk=
+github.com/ElrondNetwork/elrond-go-core v1.1.27-0.20221215101151-0e69a10c3cb5 h1:G3hGxdf54hfAKbY0IeyHs3eITMdbEa0h0csvvjHK2/o=
+github.com/ElrondNetwork/elrond-go-core v1.1.27-0.20221215101151-0e69a10c3cb5/go.mod h1:N/RI++YU2M6OlnD1GSZepc1wPhI84ykRDQ1IyD3B0wk=
 github.com/ElrondNetwork/elrond-go-logger v1.0.10 h1:2xQOWZErcHW5sl9qSRO+7mGNw+QhFhqiUlLLtOgvuuk=
 github.com/ElrondNetwork/elrond-go-logger v1.0.10/go.mod h1:+rMODFw4yQptTi5WuLUBzvl/AE26V+2YJtc52wX30Eg=
 github.com/ElrondNetwork/elrond-vm-common v1.3.27 h1:8LYa2ZCPYUXeb7USIWPHUnQnELtSyDKxmSr4QBiAYJg=

--- a/mock/elasticProcessorStub.go
+++ b/mock/elasticProcessorStub.go
@@ -17,6 +17,7 @@ type ElasticProcessorStub struct {
 		notarizedHeadersHashes []string,
 		gasConsumptionData outport.HeaderGasConsumption,
 		txsSize int,
+		pool *outport.Pool,
 	) error
 	RemoveHeaderCalled               func(header coreData.HeaderHandler) error
 	RemoveMiniblocksCalled           func(header coreData.HeaderHandler, body *block.Body) error
@@ -47,9 +48,10 @@ func (eim *ElasticProcessorStub) SaveHeader(
 	body *block.Body,
 	notarizedHeadersHashes []string,
 	gasConsumptionData outport.HeaderGasConsumption,
-	txsSize int) error {
+	txsSize int,
+	pool *outport.Pool) error {
 	if eim.SaveHeaderCalled != nil {
-		return eim.SaveHeaderCalled(headerHash, header, signersIndexes, body, notarizedHeadersHashes, gasConsumptionData, txsSize)
+		return eim.SaveHeaderCalled(headerHash, header, signersIndexes, body, notarizedHeadersHashes, gasConsumptionData, txsSize, pool)
 	}
 	return nil
 }

--- a/process/dataindexer/interface.go
+++ b/process/dataindexer/interface.go
@@ -28,6 +28,7 @@ type ElasticProcessor interface {
 		notarizedHeadersHashes []string,
 		gasConsumptionData outport.HeaderGasConsumption,
 		txsSize int,
+		pool *outport.Pool,
 	) error
 	RemoveHeader(header coreData.HeaderHandler) error
 	RemoveMiniblocks(header coreData.HeaderHandler, body *block.Body) error

--- a/process/dataindexer/workItems/interface.go
+++ b/process/dataindexer/workItems/interface.go
@@ -22,6 +22,7 @@ type saveBlockIndexer interface {
 		notarizedHeadersHashes []string,
 		gasConsumptionData outport.HeaderGasConsumption,
 		txsSize int,
+		pool *outport.Pool,
 	) error
 	SaveMiniblocks(header coreData.HeaderHandler, body *block.Body) error
 	SaveTransactions(body *block.Body, header coreData.HeaderHandler, pool *outport.Pool, coreAlteredAccounts map[string]*outport.AlteredAccount, isImportDB bool, numOfShards uint32) error

--- a/process/dataindexer/workItems/workItemBlock.go
+++ b/process/dataindexer/workItems/workItemBlock.go
@@ -71,7 +71,9 @@ func (wib *itemBlock) Save() error {
 		body,
 		wib.argsSaveBlock.NotarizedHeadersHashes,
 		wib.argsSaveBlock.HeaderGasConsumption,
-		txsSizeInBytes)
+		txsSizeInBytes,
+		wib.argsSaveBlock.TransactionsPool,
+	)
 	if err != nil {
 		return fmt.Errorf("%w when saving header block, hash %s, nonce %d",
 			err, hex.EncodeToString(wib.argsSaveBlock.HeaderHash), wib.argsSaveBlock.Header.GetNonce())

--- a/process/dataindexer/workItems/workItemBlock_test.go
+++ b/process/dataindexer/workItems/workItemBlock_test.go
@@ -54,7 +54,7 @@ func TestItemBlock_SaveHeaderShouldErr(t *testing.T) {
 	localErr := errors.New("local err")
 	itemBlock := workItems.NewItemBlock(
 		&mock.ElasticProcessorStub{
-			SaveHeaderCalled: func(headerHash []byte, header data.HeaderHandler, signersIndexes []uint64, body *dataBlock.Body, notarizedHeadersHashes []string, gasConsumptionData outport.HeaderGasConsumption, txsSize int) error {
+			SaveHeaderCalled: func(headerHash []byte, header data.HeaderHandler, signersIndexes []uint64, body *dataBlock.Body, notarizedHeadersHashes []string, gasConsumptionData outport.HeaderGasConsumption, txsSize int, _ *outport.Pool) error {
 				return localErr
 			},
 		},
@@ -75,7 +75,7 @@ func TestItemBlock_SaveNoMiniblocksShoulCallSaveHeader(t *testing.T) {
 	countCalled := 0
 	itemBlock := workItems.NewItemBlock(
 		&mock.ElasticProcessorStub{
-			SaveHeaderCalled: func(headerHash []byte, header data.HeaderHandler, signersIndexes []uint64, body *dataBlock.Body, notarizedHeadersHashes []string, gasConsumptionData outport.HeaderGasConsumption, txsSize int) error {
+			SaveHeaderCalled: func(headerHash []byte, header data.HeaderHandler, signersIndexes []uint64, body *dataBlock.Body, notarizedHeadersHashes []string, gasConsumptionData outport.HeaderGasConsumption, txsSize int, _ *outport.Pool) error {
 				countCalled++
 				return nil
 			},
@@ -148,7 +148,7 @@ func TestItemBlock_SaveShouldWork(t *testing.T) {
 	countCalled := 0
 	itemBlock := workItems.NewItemBlock(
 		&mock.ElasticProcessorStub{
-			SaveHeaderCalled: func(headerHash []byte, header data.HeaderHandler, signersIndexes []uint64, body *dataBlock.Body, notarizedHeadersHashes []string, gasConsumptionData outport.HeaderGasConsumption, txsSize int) error {
+			SaveHeaderCalled: func(headerHash []byte, header data.HeaderHandler, signersIndexes []uint64, body *dataBlock.Body, notarizedHeadersHashes []string, gasConsumptionData outport.HeaderGasConsumption, txsSize int, _ *outport.Pool) error {
 				countCalled++
 				return nil
 			},

--- a/process/elasticproc/block/blockProcessor.go
+++ b/process/elasticproc/block/blockProcessor.go
@@ -260,9 +260,9 @@ func putMiniblocksDetailsInBlock(header coreData.HeaderHandler, block *data.Bloc
 func extractExecutionOrderIndicesFromPool(mbHeader coreData.MiniBlockHeaderHandler, txsHashes [][]byte, pool *outport.Pool) []int {
 	txsMap := getTxsMap(nodeBlock.Type(mbHeader.GetTypeInt32()), pool)
 	executionOrderTxsIndices := make([]int, len(txsHashes))
-	indexOfFirstProcessed, indexOfLastProcessed := mbHeader.GetIndexOfFirstTxProcessed(), mbHeader.GetIndexOfLastTxProcessed()
+	indexOfFirstTxProcessed, indexOfLastTxProcessed := mbHeader.GetIndexOfFirstTxProcessed(), mbHeader.GetIndexOfLastTxProcessed()
 	for idx, txHash := range txsHashes {
-		isExecutedInCurrentBlock := int32(idx) >= indexOfFirstProcessed && int32(idx) <= indexOfLastProcessed
+		isExecutedInCurrentBlock := int32(idx) >= indexOfFirstTxProcessed && int32(idx) <= indexOfLastTxProcessed
 		if !isExecutedInCurrentBlock {
 			executionOrderTxsIndices[idx] = notExecutedInCurrentBlock
 			continue
@@ -343,7 +343,7 @@ func getTxsMap(mbType nodeBlock.Type, pool *outport.Pool) map[string]coreData.Tr
 	case nodeBlock.SmartContractResultBlock:
 		return pool.Scrs
 	default:
-		return map[string]coreData.TransactionHandlerWithGasUsedAndFee{}
+		return make(map[string]coreData.TransactionHandlerWithGasUsedAndFee)
 	}
 }
 

--- a/process/elasticproc/block/blockProcessor_test.go
+++ b/process/elasticproc/block/blockProcessor_test.go
@@ -297,11 +297,11 @@ func TestBlockProcessor_PrepareBlockForDBMiniBlocksDetails(t *testing.T) {
 
 	mbhr := &dataBlock.MiniBlockHeaderReserved{
 		IndexOfFirstTxProcessed: 0,
-		IndexOfLastTxProcessed:  0,
+		IndexOfLastTxProcessed:  1,
 	}
 	mbhrBytes, _ := gogoMarshaller.Marshal(mbhr)
 
-	txHash, notExecutedTxHash, invalidTxHash, rewardsTxHash, scrHash := "tx", "notExecuted", "invalid", "reward", "scr"
+	txHash, notExecutedTxHash, notFoundTxHash, invalidTxHash, rewardsTxHash, scrHash := "tx", "notExecuted", "notFound", "invalid", "reward", "scr"
 	dbBlock, err := bp.PrepareBlockForDB([]byte("hash"), &dataBlock.Header{
 		TxCount: 5,
 		MiniBlockHeaders: []dataBlock.MiniBlockHeader{
@@ -327,7 +327,7 @@ func TestBlockProcessor_PrepareBlockForDBMiniBlocksDetails(t *testing.T) {
 		MiniBlocks: []*dataBlock.MiniBlock{
 			{
 				Type:     dataBlock.TxBlock,
-				TxHashes: [][]byte{[]byte(txHash), []byte(notExecutedTxHash)},
+				TxHashes: [][]byte{[]byte(txHash), []byte(notFoundTxHash), []byte(notExecutedTxHash)},
 			},
 			{
 				Type:     dataBlock.RewardsBlock,
@@ -370,13 +370,13 @@ func TestBlockProcessor_PrepareBlockForDBMiniBlocksDetails(t *testing.T) {
 
 	require.Equal(t, &data.Block{
 		Hash:            "68617368",
-		Size:            int64(308),
+		Size:            int64(341),
 		AccumulatedFees: "0",
 		DeveloperFees:   "0",
 		TxCount:         uint32(5),
 		SearchOrder:     uint64(1020),
 		MiniBlocksHashes: []string{
-			"a0b43cf86fd05da82124088b2b492e73bb8881acddef2b29e0a1cde62cc5bb4c",
+			"ee29d9b4a5017b7351974110d6a3f28ce6612476582f16b7849e3e87c647fc2d",
 			"c067de5b3c0031a14578699b1c3cdb9a19039e4a7b3fae6a94932ad3f70cf375",
 			"758f925b254ea0a6ad1bcbe3ddfcc73418ed4c8712506aafddc4da703295ad63",
 			"28a96506c2999838923f5310b3bb1d6849b5a259b429790d9eeb21c2a1402f82",
@@ -384,12 +384,12 @@ func TestBlockProcessor_PrepareBlockForDBMiniBlocksDetails(t *testing.T) {
 		MiniBlocksDetails: []*data.MiniBlocksDetails{
 			{
 				IndexFirstProcessedTx:    0,
-				IndexLastProcessedTx:     0,
+				IndexLastProcessedTx:     1,
 				MBIndex:                  0,
 				Type:                     dataBlock.TxBlock.String(),
 				ProcessingType:           dataBlock.Normal.String(),
-				ExecutionOrderTxsIndices: []int{2, notExecutedInCurrentBlock},
-				TxsHashes:                []string{"7478", "6e6f744578656375746564"},
+				ExecutionOrderTxsIndices: []int{2, notFound, notExecutedInCurrentBlock},
+				TxsHashes:                []string{"7478", "6e6f74466f756e64", "6e6f744578656375746564"},
 			},
 			{
 				IndexFirstProcessedTx:    0,

--- a/process/elasticproc/block/blockProcessor_test.go
+++ b/process/elasticproc/block/blockProcessor_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ElrondNetwork/elastic-indexer-go/mock"
 	indexer "github.com/ElrondNetwork/elastic-indexer-go/process/dataindexer"
 	"github.com/ElrondNetwork/elrond-go-core/core"
+	coreData "github.com/ElrondNetwork/elrond-go-core/data"
 	dataBlock "github.com/ElrondNetwork/elrond-go-core/data/block"
 	"github.com/ElrondNetwork/elrond-go-core/data/outport"
 	"github.com/ElrondNetwork/elrond-go-core/hashing"
@@ -72,7 +73,7 @@ func TestBlockProcessor_PrepareBlockForDBShouldWork(t *testing.T) {
 					ReceiverShardID: 2,
 				},
 			},
-		}, nil, outport.HeaderGasConsumption{}, 0)
+		}, nil, outport.HeaderGasConsumption{}, 0, &outport.Pool{})
 	require.Nil(t, err)
 
 	expectedBlock := &data.Block{
@@ -94,7 +95,7 @@ func TestBlockProcessor_PrepareBlockForDBNilHeader(t *testing.T) {
 
 	bp, _ := NewBlockProcessor(&mock.HasherMock{}, &mock.MarshalizerMock{})
 
-	dbBlock, err := bp.PrepareBlockForDB([]byte("hash"), nil, nil, &dataBlock.Body{}, nil, outport.HeaderGasConsumption{}, 0)
+	dbBlock, err := bp.PrepareBlockForDB([]byte("hash"), nil, nil, &dataBlock.Body{}, nil, outport.HeaderGasConsumption{}, 0, &outport.Pool{})
 	require.Equal(t, indexer.ErrNilHeaderHandler, err)
 	require.Nil(t, dbBlock)
 }
@@ -104,7 +105,7 @@ func TestBlockProcessor_PrepareBlockForDBNilBody(t *testing.T) {
 
 	bp, _ := NewBlockProcessor(&mock.HasherMock{}, &mock.MarshalizerMock{})
 
-	dbBlock, err := bp.PrepareBlockForDB([]byte("hash"), &dataBlock.MetaBlock{}, nil, nil, nil, outport.HeaderGasConsumption{}, 0)
+	dbBlock, err := bp.PrepareBlockForDB([]byte("hash"), &dataBlock.MetaBlock{}, nil, nil, nil, outport.HeaderGasConsumption{}, 0, &outport.Pool{})
 	require.Equal(t, indexer.ErrNilBlockBody, err)
 	require.Nil(t, dbBlock)
 }
@@ -119,7 +120,7 @@ func TestBlockProcessor_PrepareBlockForDBMarshalFailHeader(t *testing.T) {
 		},
 	})
 
-	dbBlock, err := bp.PrepareBlockForDB([]byte("hash"), &dataBlock.MetaBlock{}, nil, &dataBlock.Body{}, nil, outport.HeaderGasConsumption{}, 0)
+	dbBlock, err := bp.PrepareBlockForDB([]byte("hash"), &dataBlock.MetaBlock{}, nil, &dataBlock.Body{}, nil, outport.HeaderGasConsumption{}, 0, &outport.Pool{})
 	require.Equal(t, expectedErr, err)
 	require.Nil(t, dbBlock)
 }
@@ -141,7 +142,7 @@ func TestBlockProcessor_PrepareBlockForDBMarshalFailBlock(t *testing.T) {
 		},
 	})
 
-	dbBlock, err := bp.PrepareBlockForDB([]byte("hash"), &dataBlock.MetaBlock{}, nil, &dataBlock.Body{}, nil, outport.HeaderGasConsumption{}, 0)
+	dbBlock, err := bp.PrepareBlockForDB([]byte("hash"), &dataBlock.MetaBlock{}, nil, &dataBlock.Body{}, nil, outport.HeaderGasConsumption{}, 0, &outport.Pool{})
 	require.Equal(t, expectedErr, err)
 	require.Nil(t, dbBlock)
 }
@@ -204,19 +205,24 @@ func TestBlockProcessor_PrepareBlockForDBEpochStartMeta(t *testing.T) {
 				TxCount: 120,
 			},
 		},
-	}, nil, &dataBlock.Body{}, nil, outport.HeaderGasConsumption{}, 0)
+	}, nil, &dataBlock.Body{
+		MiniBlocks: []*dataBlock.MiniBlock{
+			{},
+			{},
+		},
+	}, nil, outport.HeaderGasConsumption{}, 0, &outport.Pool{})
 	require.Equal(t, nil, err)
 	require.Equal(t, &data.Block{
 		Nonce:                 0,
 		Round:                 0,
 		Epoch:                 0,
 		Hash:                  "68617368",
-		MiniBlocksHashes:      []string{},
+		MiniBlocksHashes:      []string{"44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a", "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"},
 		NotarizedBlocksHashes: nil,
 		Proposer:              0,
 		Validators:            nil,
 		PubKeyBitmap:          "",
-		Size:                  623,
+		Size:                  643,
 		SizeTxs:               0,
 		Timestamp:             0,
 		StateRootHash:         "",
@@ -236,14 +242,22 @@ func TestBlockProcessor_PrepareBlockForDBEpochStartMeta(t *testing.T) {
 		},
 		MiniBlocksDetails: []*data.MiniBlocksDetails{
 			{
-				IndexFirstProcessedTx: 0,
-				IndexLastProcessedTx:  49,
-				MBIndex:               0,
+				IndexFirstProcessedTx:    0,
+				IndexLastProcessedTx:     49,
+				MBIndex:                  0,
+				Type:                     dataBlock.TxBlock.String(),
+				ProcessingType:           dataBlock.Normal.String(),
+				ExecutionOrderTxsIndices: []int{},
+				TxsHashes:                []string{},
 			},
 			{
-				IndexFirstProcessedTx: 0,
-				IndexLastProcessedTx:  119,
-				MBIndex:               1,
+				IndexFirstProcessedTx:    0,
+				IndexLastProcessedTx:     119,
+				MBIndex:                  1,
+				Type:                     dataBlock.TxBlock.String(),
+				ProcessingType:           dataBlock.Normal.String(),
+				ExecutionOrderTxsIndices: []int{},
+				TxsHashes:                []string{},
 			},
 		},
 		EpochStartShardsData: []*data.EpochStartShardData{
@@ -272,5 +286,123 @@ func TestBlockProcessor_PrepareBlockForDBEpochStartMeta(t *testing.T) {
 		TxCount:           170,
 		AccumulatedFees:   "0",
 		DeveloperFees:     "0",
+	}, dbBlock)
+}
+
+func TestBlockProcessor_PrepareBlockForDBMiniBlocksDetails(t *testing.T) {
+	t.Parallel()
+
+	bp, _ := NewBlockProcessor(&mock.HasherMock{}, &mock.MarshalizerMock{})
+
+	txHash, invalidTxHash, rewardsTxHash, scrHash := "tx", "invalid", "reward", "scr"
+	dbBlock, err := bp.PrepareBlockForDB([]byte("hash"), &dataBlock.Header{
+		TxCount: 4,
+		MiniBlockHeaders: []dataBlock.MiniBlockHeader{
+			{
+				TxCount: 1,
+				Type:    dataBlock.TxBlock,
+			},
+			{
+				TxCount: 1,
+				Type:    dataBlock.RewardsBlock,
+			},
+			{
+				TxCount: 1,
+				Type:    dataBlock.InvalidBlock,
+			},
+			{
+				TxCount: 1,
+				Type:    dataBlock.SmartContractResultBlock,
+			},
+		},
+	}, nil, &dataBlock.Body{
+		MiniBlocks: []*dataBlock.MiniBlock{
+			{
+				Type:     dataBlock.TxBlock,
+				TxHashes: [][]byte{[]byte(txHash)},
+			},
+			{
+				Type:     dataBlock.RewardsBlock,
+				TxHashes: [][]byte{[]byte(rewardsTxHash)},
+			},
+			{
+				Type:     dataBlock.InvalidBlock,
+				TxHashes: [][]byte{[]byte(invalidTxHash)},
+			},
+			{
+				Type:     dataBlock.SmartContractResultBlock,
+				TxHashes: [][]byte{[]byte(scrHash)},
+			},
+		},
+	}, nil, outport.HeaderGasConsumption{}, 0, &outport.Pool{
+		Txs: map[string]coreData.TransactionHandlerWithGasUsedAndFee{
+			txHash: &outport.TransactionHandlerWithGasAndFee{
+				ExecutionOrder: 2,
+			},
+		},
+		Rewards: map[string]coreData.TransactionHandlerWithGasUsedAndFee{
+			rewardsTxHash: &outport.TransactionHandlerWithGasAndFee{
+				ExecutionOrder: 3,
+			},
+		},
+		Invalid: map[string]coreData.TransactionHandlerWithGasUsedAndFee{
+			invalidTxHash: &outport.TransactionHandlerWithGasAndFee{
+				ExecutionOrder: 1,
+			}},
+		Scrs: map[string]coreData.TransactionHandlerWithGasUsedAndFee{
+			scrHash: &outport.TransactionHandlerWithGasAndFee{
+				ExecutionOrder: 0,
+			},
+		},
+	})
+	require.Nil(t, err)
+
+	require.Equal(t, &data.Block{
+		Hash:            "68617368",
+		Size:            int64(289),
+		AccumulatedFees: "0",
+		DeveloperFees:   "0",
+		TxCount:         uint32(4),
+		SearchOrder:     uint64(1020),
+		MiniBlocksHashes: []string{
+			"053c84b97d2a302bc9311ea3fae87234a728df41c0815404f0cf269b8ff5a59d",
+			"c067de5b3c0031a14578699b1c3cdb9a19039e4a7b3fae6a94932ad3f70cf375",
+			"758f925b254ea0a6ad1bcbe3ddfcc73418ed4c8712506aafddc4da703295ad63",
+			"28a96506c2999838923f5310b3bb1d6849b5a259b429790d9eeb21c2a1402f82",
+		},
+		MiniBlocksDetails: []*data.MiniBlocksDetails{
+			{
+				IndexFirstProcessedTx:    0,
+				IndexLastProcessedTx:     0,
+				MBIndex:                  0,
+				Type:                     dataBlock.TxBlock.String(),
+				ProcessingType:           dataBlock.Normal.String(),
+				ExecutionOrderTxsIndices: []int{2},
+				TxsHashes:                []string{"7478"},
+			},
+			{
+				IndexFirstProcessedTx:    0,
+				IndexLastProcessedTx:     0,
+				MBIndex:                  1,
+				Type:                     dataBlock.RewardsBlock.String(),
+				ProcessingType:           dataBlock.Normal.String(),
+				ExecutionOrderTxsIndices: []int{3},
+				TxsHashes:                []string{"726577617264"},
+			},
+			{IndexFirstProcessedTx: 0,
+				IndexLastProcessedTx:     0,
+				MBIndex:                  2,
+				Type:                     dataBlock.InvalidBlock.String(),
+				ProcessingType:           dataBlock.Normal.String(),
+				ExecutionOrderTxsIndices: []int{1},
+				TxsHashes:                []string{"696e76616c6964"}},
+			{IndexFirstProcessedTx: 0,
+				IndexLastProcessedTx:     0,
+				MBIndex:                  3,
+				Type:                     dataBlock.SmartContractResultBlock.String(),
+				ProcessingType:           dataBlock.Normal.String(),
+				ExecutionOrderTxsIndices: []int{0},
+				TxsHashes:                []string{"736372"}},
+		},
 	}, dbBlock)
 }

--- a/process/elasticproc/elasticProcessor.go
+++ b/process/elasticproc/elasticProcessor.go
@@ -250,12 +250,13 @@ func (ei *elasticProcessor) SaveHeader(
 	notarizedHeadersHashes []string,
 	gasConsumptionData outport.HeaderGasConsumption,
 	txsSize int,
+	pool *outport.Pool,
 ) error {
 	if !ei.isIndexEnabled(elasticIndexer.BlockIndex) {
 		return nil
 	}
 
-	elasticBlock, err := ei.blockProc.PrepareBlockForDB(headerHash, header, signersIndexes, body, notarizedHeadersHashes, gasConsumptionData, txsSize)
+	elasticBlock, err := ei.blockProc.PrepareBlockForDB(headerHash, header, signersIndexes, body, notarizedHeadersHashes, gasConsumptionData, txsSize, pool)
 	if err != nil {
 		return err
 	}

--- a/process/elasticproc/elasticProcessor_test.go
+++ b/process/elasticproc/elasticProcessor_test.go
@@ -360,7 +360,7 @@ func TestElasticseachDatabaseSaveHeader_RequestError(t *testing.T) {
 	arguments.BlockProc, _ = block.NewBlockProcessor(&mock.HasherMock{}, &mock.MarshalizerMock{})
 	elasticDatabase := newElasticsearchProcessor(dbWriter, arguments)
 
-	err := elasticDatabase.SaveHeader([]byte("hh"), header, signerIndexes, &dataBlock.Body{}, nil, outport.HeaderGasConsumption{}, 1)
+	err := elasticDatabase.SaveHeader([]byte("hh"), header, signerIndexes, &dataBlock.Body{}, nil, outport.HeaderGasConsumption{}, 1, &outport.Pool{})
 	require.Equal(t, localErr, err)
 }
 
@@ -401,7 +401,7 @@ func TestElasticseachDatabaseSaveHeader_CheckRequestBody(t *testing.T) {
 
 	arguments.BlockProc, _ = block.NewBlockProcessor(&mock.HasherMock{}, &mock.MarshalizerMock{})
 	elasticDatabase := newElasticsearchProcessor(dbWriter, arguments)
-	err := elasticDatabase.SaveHeader([]byte("hh"), header, signerIndexes, blockBody, nil, outport.HeaderGasConsumption{}, 1)
+	err := elasticDatabase.SaveHeader([]byte("hh"), header, signerIndexes, blockBody, nil, outport.HeaderGasConsumption{}, 1, &outport.Pool{})
 	require.Nil(t, err)
 }
 
@@ -623,7 +623,7 @@ func TestElasticProcessor_IndexEpochInfoData(t *testing.T) {
 	body := &dataBlock.Body{}
 	metaHeader := &dataBlock.MetaBlock{}
 
-	err = elasticSearchProc.SaveHeader([]byte("hh"), metaHeader, nil, body, nil, outport.HeaderGasConsumption{}, 0)
+	err = elasticSearchProc.SaveHeader([]byte("hh"), metaHeader, nil, body, nil, outport.HeaderGasConsumption{}, 0, &outport.Pool{})
 	require.Nil(t, err)
 	require.True(t, called)
 }

--- a/process/elasticproc/interface.go
+++ b/process/elasticproc/interface.go
@@ -53,6 +53,7 @@ type DBBlockHandler interface {
 		notarizedHeadersHashes []string,
 		gasConsumptionData outport.HeaderGasConsumption,
 		sizeTxs int,
+		pool *outport.Pool,
 	) (*data.Block, error)
 	ComputeHeaderHash(header coreData.HeaderHandler) ([]byte, error)
 


### PR DESCRIPTION
- Added transactions execution order in the `Block` structure.
- Added transactions hashes hex-encoded in the `MiniblockDetails` structure from the `Block` strucutre